### PR TITLE
Add EV calculations using historical MLB data

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,6 +159,101 @@ def player_match(name_a: str, name_b: str, threshold: int = PLAYER_MATCH_THRESHO
     score = _fuzzy_ratio(_normalize_name(name_a), _normalize_name(name_b))
     return score >= threshold
 
+# --------------- EV CALCULATIONS -----------------
+def american_to_decimal(odds: float) -> float:
+    """Convert American odds to decimal odds."""
+    odds = float(odds)
+    if odds > 0:
+        return 1 + odds / 100
+    return 1 + 100 / abs(odds)
+
+
+def american_to_prob(odds: float) -> float:
+    """Return implied probability from American odds."""
+    odds = float(odds)
+    if odds > 0:
+        return 100 / (odds + 100)
+    return abs(odds) / (abs(odds) + 100)
+
+
+def remove_hold(over_odds: float, under_odds: float):
+    """Return sportsbook hold and normalized probabilities for each side."""
+    p_over = american_to_prob(over_odds)
+    p_under = american_to_prob(under_odds)
+    total = p_over + p_under
+    if total == 0:
+        return 0, 0, 0
+    hold = total - 1
+    return hold, p_over / total, p_under / total
+
+
+def compute_ev(true_prob: float, odds: float) -> float:
+    """Return expected value for a bet with given true probability and odds."""
+    dec = american_to_decimal(odds)
+    return true_prob * dec - 1
+
+
+def fetch_player_over_probability(player_name: str, stat: str, line: float, season: str = None, games: int = 100):
+    """Return probability of player going over a line using MLB Stats API.
+
+    This function queries the public MLB Stats API to retrieve recent game logs
+    for a player and calculates the proportion of games in which the specified
+    stat went over the provided line. Theoddsapi is deliberately not used so
+    historical performance comes from a different source.
+    """
+    try:
+        search_url = (
+            "https://statsapi.mlb.com/api/v1/people/search?name="
+            + urllib.parse.quote(player_name)
+        )
+        with urllib.request.urlopen(search_url) as resp:
+            search_data = json.loads(resp.read().decode())
+        results = search_data.get("people") or []
+        if not results:
+            return None
+        player_id = results[0]["id"]
+        params = {
+            "stats": "gameLog",
+            "group": "hitting",
+            "sportId": 1,
+            "limit": games,
+        }
+        if season:
+            params["season"] = season
+        url = (
+            f"https://statsapi.mlb.com/api/v1/people/{player_id}/stats?"
+            + urllib.parse.urlencode(params)
+        )
+        with urllib.request.urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:  # network or parse error
+        print("Historical data error:", exc)
+        return None
+
+    splits = (
+        data.get("stats", [{}])[0]
+        .get("splits", [])
+    )
+    if not splits:
+        return None
+
+    over = 0
+    total = 0
+    for g in splits:
+        stat_val = g.get("stat", {}).get(stat)
+        if stat_val is None:
+            continue
+        try:
+            val = float(stat_val)
+        except Exception:
+            continue
+        total += 1
+        if val > line:
+            over += 1
+    if total == 0:
+        return None
+    return over / total
+
 # --------------- FETCH UNDERDOG MLB PROPS -----------------
 def fetch_underdog_props():
     params = {
@@ -225,6 +320,45 @@ def aggregate_consensus_line(cons_props, market_keys, player_name):
         return sum(lines) / len(lines), sorted(set(books))
     return None, []
 
+
+def aggregate_market_with_odds(cons_props, market_keys, player_name):
+    """Aggregate line and odds data for a player across bookmakers."""
+    lines = []
+    over_prices = []
+    under_prices = []
+    books = []
+    for game in cons_props:
+        for bookmaker in game.get("bookmakers", []):
+            if bookmaker.get("key") not in BOOKMAKER_KEYS:
+                continue
+            for market in bookmaker.get("markets", []):
+                if market.get("key") not in market_keys:
+                    continue
+                for outcome in market.get("outcomes", []):
+                    if player_match(player_name, outcome.get("name", "")):
+                        line = outcome.get("point")
+                        if line is not None:
+                            try:
+                                lines.append(float(line))
+                            except Exception:
+                                pass
+                        price = outcome.get("price")
+                        if price is not None:
+                            try:
+                                price_f = float(price)
+                                name = outcome.get("name", "").lower()
+                                if "over" in name:
+                                    over_prices.append(price_f)
+                                elif "under" in name:
+                                    under_prices.append(price_f)
+                            except Exception:
+                                pass
+                        books.append(bookmaker.get("title", bookmaker.get("key")))
+    avg_line = sum(lines) / len(lines) if lines else None
+    avg_over = sum(over_prices) / len(over_prices) if over_prices else None
+    avg_under = sum(under_prices) / len(under_prices) if under_prices else None
+    return avg_line, avg_over, avg_under, sorted(set(books))
+
 # --------------- FIND VALUE PROPS -----------------
 def find_value_props(ud_props, cons_props, threshold=EDGE_THRESHOLD):
     value_props = []
@@ -249,6 +383,41 @@ def find_value_props(ud_props, cons_props, threshold=EDGE_THRESHOLD):
             except Exception as e:
                 print("Parse error:", e)
     return value_props
+
+
+def find_ev_props(ud_props, cons_props, games=100):
+    """Return props with calculated expected value using historical data."""
+    ev_props = []
+    for u in ud_props:
+        market_keys = get_market_keys(u["stat"])
+        if not market_keys:
+            continue
+        line, over_price, under_price, books = aggregate_market_with_odds(
+            cons_props, market_keys, u["player"]
+        )
+        if line is None or over_price is None or under_price is None:
+            continue
+        true_over_prob = fetch_player_over_probability(u["player"], _normalize_stat_name(u["stat"]), line, games=games)
+        if true_over_prob is None:
+            continue
+        hold, imp_over, imp_under = remove_hold(over_price, under_price)
+        ev_over = compute_ev(true_over_prob, over_price)
+        ev_under = compute_ev(1 - true_over_prob, under_price)
+        ev_props.append({
+            "player": u["player"],
+            "stat": u["stat"],
+            "line": line,
+            "over_odds": over_price,
+            "under_odds": under_price,
+            "book": ", ".join(books) if books else "consensus",
+            "historical_over_prob": true_over_prob,
+            "implied_over_prob": imp_over,
+            "implied_under_prob": imp_under,
+            "hold": hold,
+            "ev_over": ev_over,
+            "ev_under": ev_under,
+        })
+    return ev_props
 
 # --------------- TELEGRAM ALERT -----------------
 def send_telegram_message(message):
@@ -317,10 +486,27 @@ if __name__ == "__main__":
         action="store_true",
         help="Track line history without sending Telegram alerts",
     )
+    parser.add_argument(
+        "--ev-once",
+        action="store_true",
+        help="Calculate expected value using historical data and exit",
+    )
     args = parser.parse_args()
 
     if args.plot:
         init_db()
         plot_line_history(args.plot)
+    elif args.ev_once:
+        print("Fetching Underdog MLB props...")
+        ud_props = fetch_underdog_props()
+        print("Fetching consensus props...")
+        cons_props = fetch_consensus_props()
+        ev_props = find_ev_props(ud_props, cons_props)
+        for p in ev_props:
+            print(
+                f"{p['player']} {p['stat']} line {p['line']} "
+                f"Over EV: {p['ev_over']:.3f} Under EV: {p['ev_under']:.3f} "
+                f"Hold: {p['hold']:.3f}"
+            )
     else:
         main_loop(track_only=args.track_only)


### PR DESCRIPTION
## Summary
- add utilities to convert American odds and remove sportsbook hold
- fetch historical player outcomes from MLB Stats API
- compute expected value for props
- expose new `--ev-once` CLI flag to print EV calculations

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68413e5e3eec832cb415c63338957fbe