### PR TITLE
Fix .env loading without python-dotenv

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,16 @@ try:
     from dotenv import load_dotenv
     load_dotenv()
 except Exception:
-    pass
+    # Fallback to manual .env parsing if python-dotenv isn't available
+    env_path = os.path.join(os.path.dirname(__file__), ".env")
+    if os.path.exists(env_path):
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key, value)
 from datetime import datetime
 from difflib import SequenceMatcher
 import random


### PR DESCRIPTION
## Summary
- if python-dotenv is missing, parse the `.env` file manually so env vars like `TELEGRAM_BOT_TOKEN` populate properly

## Testing
- `python3 main.py --offline --track-only`

------
https://chatgpt.com/codex/tasks/task_e_6841e70d7efc832ca05ef917e5f8c79c