### PR TITLE
Add events endpoint support

### DIFF
--- a/main.py
+++ b/main.py
@@ -926,6 +926,22 @@ def fetch_scores(sport: str, days_from: int = 1, date_format: str = "iso") -> li
         _notify_error(f"Scores fetch failed: {exc}")
         return []
 
+def fetch_events(sport: str) -> list:
+    """Retrieve upcoming events for a sport from TheOdds API."""
+    if OFFLINE:
+        return []
+    url = f"https://api.the-odds-api.com/v4/sports/{sport}/events"
+    params = {"apiKey": THE_ODDS_API_KEY}
+    query_params = urllib.parse.urlencode(params)
+    try:
+        with urllib.request.urlopen(f"{url}?{query_params}") as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"TheOdds API error: {resp.status}")
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        _notify_error(f"Events fetch failed: {exc}")
+        return []
+
 # --------------- FETCH CONSENSUS MLB PROPS -----------------
 def fetch_consensus_props():
     if OFFLINE:
@@ -1714,6 +1730,11 @@ if __name__ == "__main__":
         help="Fetch recent scores for a sport from TheOdds API and exit",
     )
     parser.add_argument(
+        "--events",
+        metavar="SPORT",
+        help="Fetch upcoming events for a sport from TheOdds API and exit",
+    )
+    parser.add_argument(
         "--days-from",
         type=int,
         default=1,
@@ -1801,6 +1822,9 @@ if __name__ == "__main__":
                 prob = item["prob"]
                 prob_str = f"{prob:.3f}" if prob is not None else "N/A"
                 print(f"Cluster {item['cluster']} | {item['player']} -> {prob_str}")
+    elif args.events:
+        events = fetch_events(args.events)
+        print(json.dumps(events, indent=2))
     elif args.scores:
         scores = fetch_scores(
             args.scores, days_from=args.days_from, date_format=args.date_format


### PR DESCRIPTION
## Summary
- implement `fetch_events` to call TheOdds API events endpoint
- expose `--events` CLI option
- allow printing events from CLI

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f173e134832ca30dbb17cf27a093