### PR TITLE
Handle dynamic MLB markets

### DIFF
--- a/main.py
+++ b/main.py
@@ -941,7 +941,7 @@ def fetch_events(sport: str) -> list:
         return []
 
 def get_valid_mlb_markets() -> list:
-    """Return available MLB markets from TheOdds API."""
+    """Fetch the list of valid markets for MLB from The Odds API."""
     url = (
         f"https://api.the-odds-api.com/v4/sports/baseball_mlb/?apiKey={THE_ODDS_API_KEY}"
     )
@@ -950,12 +950,12 @@ def get_valid_mlb_markets() -> list:
             if resp.status != 200:
                 raise RuntimeError(f"TheOdds API error: {resp.status}")
             data = json.loads(resp.read().decode())
-            # The API returns a list of all supported markets
+            # Return all available markets (not just h2h, spreads, totals)
             return data.get("markets", [])
     except Exception as exc:
         print("Could not fetch valid markets for MLB:", exc)
-        # Fallback to safe defaults
-        return ["h2h", "totals", "spreads"]
+        # Fallback to a safe default
+        return ["h2h"]
 
 # --------------- FETCH CONSENSUS MLB PROPS -----------------
 def fetch_consensus_props():
@@ -968,17 +968,16 @@ def fetch_consensus_props():
         return []
     # Determine which markets the API currently supports for MLB
     valid_markets = get_valid_mlb_markets()
-
-    # Use only markets that are both defined in STAT_KEY_MAP and supported
-    valid_player_markets = [m for m in ALL_MARKETS.split(",") if m in valid_markets]
-    if not valid_player_markets:
-        # Fallback to a basic market if none are returned
-        valid_player_markets = ["h2h"]
+    # Only use markets we request that are also valid for MLB
+    requested_markets = [m for m in ALL_MARKETS.split(",") if m in valid_markets]
+    if not requested_markets:
+        # If no player markets are valid, fallback to h2h
+        requested_markets = ["h2h"]
     url = f"https://api.the-odds-api.com/v4/sports/{mlb['key']}/odds"
     params = {
         "apiKey": THE_ODDS_API_KEY,
         "regions": "us",
-        "markets": ",".join(valid_player_markets),
+        "markets": ",".join(requested_markets),
         "oddsFormat": "american",
         "bookmakers": ",".join(BOOKMAKER_KEYS),
     }


### PR DESCRIPTION
## Summary
- allow dynamic MLB market configuration based on The Odds API
- handle missing market list by falling back to `h2h`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6841fd8e1cc8832c82f4d3a324ab66e7