### PR TITLE
Improve odds output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Odds Fetcher
+
+This script fetches odds from [The Odds API](https://the-odds-api.com/).
+
+## Usage
+
+1. Set an environment variable with your API key:
+
+```bash
+export THE_ODDS_API_KEY=<your api key>
+```
+
+2. Run the script:
+
+```bash
+python main.py
+```
+
+The script prints the API endpoint containing the `h2h` market and displays
+head-to-head (moneyline) lines for each game in a clean layout.


### PR DESCRIPTION
## Summary
- print the full API URL using a helper function
- display head-to-head lines with an explicit label
- document usage in a new README

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6842b0e9ccc4832cbbc67307f9c5c137