### PR TITLE
Add spreads command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ This script fetches odds from [The Odds API](https://the-odds-api.com/).
 export THE_ODDS_API_KEY=<your api key>
 ```
 
-2. Run the script:
+2. Run the script (moneyline odds shown by default):
 
 ```bash
 python main.py
 ```
 
-The script prints the API endpoint containing the `h2h` market and displays
-head-to-head (moneyline) lines for each game in a clean layout.
+To display point spread (handicap) odds, run:
+
+```bash
+python main.py spreads
+```
+
+The script requests both head-to-head and point spread markets. It prints the
+API endpoint used and displays odds for the selected market in a clean layout.


### PR DESCRIPTION
## Summary
- support CLI subcommand for spreads
- show moneyline or spread odds based on command
- request both h2h and spread markets
- document usage in the README

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv)*
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6842b307811c832ca9d10254cbf40668