### PR TITLE
Add totals market support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,12 @@ To display point spread (handicap) odds, run:
 python main.py spreads
 ```
 
-The script requests both head-to-head and point spread markets. It prints the
-API endpoint used and displays odds for the selected market in a clean layout.
+To display totals (over/under) odds, run:
+
+```bash
+python main.py totals
+```
+
+The script requests head-to-head, point spread, and totals markets. It prints
+the API endpoint used and displays odds for the selected market in a clean
+layout.

--- a/main.py
+++ b/main.py
@@ -117,12 +117,36 @@ def format_spreads(games):
     return "\n".join(lines)
 
 
+def format_totals(games):
+    """Return a formatted string of totals (over/under) odds for display."""
+    lines = []
+    for idx, game in enumerate(games, 1):
+        lines.append(_format_header(idx, game))
+        lines.append("   Totals (Over/Under):")
+
+        for bookmaker in game.get("bookmakers", []):
+            bm_title = bookmaker.get("title", bookmaker.get("key", ""))
+            for market in bookmaker.get("markets", []):
+                if market.get("key") != "totals":
+                    continue
+                outcomes = [
+                    f"{o.get('name', '')} {o.get('point', '')} ({o.get('price', '')})"
+                    for o in market.get("outcomes", [])
+                ]
+                if outcomes:
+                    lines.append(f"      {bm_title}: " + " | ".join(outcomes))
+                break
+        lines.append("")
+
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fetch and display odds")
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["moneyline", "spreads"],
+        choices=["moneyline", "spreads", "totals"],
         default="moneyline",
         help="Type of odds to display",
     )
@@ -133,7 +157,7 @@ def main():
     )
     args = parser.parse_args()
 
-    markets = "h2h,spreads"
+    markets = "h2h,spreads,totals"
     url = build_odds_url(args.sport, markets=markets)
     print(f"Fetching {args.command} odds for {args.sport}...\n{url}\n")
     odds = fetch_odds(args.sport, markets=markets)
@@ -144,8 +168,10 @@ def main():
 
     if args.command == "moneyline":
         print(format_moneyline(odds))
-    else:
+    elif args.command == "spreads":
         print(format_spreads(odds))
+    else:
+        print(format_totals(odds))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend CLI to allow a `totals` command
- fetch `totals` market in addition to `h2h` and `spreads`
- implement `format_totals` to display over/under odds
- document the new functionality in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b4f87774832caaddefc603d79654