### PR TITLE
Add futures support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ To display totals (over/under) odds, run:
 python main.py totals
 ```
 
-The script requests head-to-head, point spread, and totals markets. It prints
+To display outrights (futures) odds, run:
+
+```bash
+python main.py outrights
+```
+
+The script requests head-to-head, point spread, totals, and outright markets as
+needed. It prints
 the API endpoint used and displays odds for the selected market in a clean
 layout.


### PR DESCRIPTION
## Summary
- support fetching outrights/futures odds
- document outrights usage in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b5cc6504832cab37486aa2f5f662