### PR TITLE
Add historical odds endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ To display outrights (futures) odds, run:
 python main.py outrights
 ```
 
+To display historical odds for a specific date, run:
+
+```bash
+python main.py historical --date=2024-01-01
+```
+
 The script requests head-to-head, point spread, totals, and outright markets as
 needed. It prints
 the API endpoint used and displays odds for the selected market in a clean


### PR DESCRIPTION
## Summary
- add support for fetching historical odds
- expose new CLI option `historical` with `--date`
- document historical odds usage

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c14a4c8c832ca26992e47e4d7538