### PR TITLE
Add continuous training command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,16 @@ python main.py predict_classifier --features='{"home_team_stat":1.2,"away_team_s
 ```
 
 The command prints the home team win probability.
+
+To keep the classifier up to date without manually running a command each time,
+use the continuous training mode. This repeatedly fetches historical data from a
+start date up to the current day and retrains the model on a fixed interval
+(24&nbsp;hours by default):
+
+```bash
+python main.py continuous_train_classifier --sport=baseball_mlb \
+    --start-date=2024-04-01 --interval-hours=24
+```
+
+The process runs indefinitely until interrupted and writes the model to the path
+given by ``--model-out`` after each training cycle.

--- a/main.py
+++ b/main.py
@@ -371,6 +371,7 @@ def main():
             "historical",
             "train_classifier",
             "predict_classifier",
+            "continuous_train_classifier",
         ],
         default="moneyline",
         help="Type of odds to display",
@@ -420,6 +421,12 @@ def main():
         default=None,
         help="End date for training data in YYYY-MM-DD format",
     )
+    parser.add_argument(
+        "--interval-hours",
+        type=int,
+        default=24,
+        help="Interval between training runs in hours for continuous training",
+    )
     args = parser.parse_args()
 
     if args.command == "train_classifier":
@@ -452,6 +459,19 @@ def main():
         feature_values = json.loads(args.features)
         prob = predict_win_probability(args.model, feature_values)
         print(f"Home win probability: {prob:.3f}")
+        return
+
+    if args.command == "continuous_train_classifier":
+        from ml import continuous_train_classifier
+
+        if not args.start_date:
+            parser.error("--start-date is required for continuous_train_classifier")
+        continuous_train_classifier(
+            args.sport,
+            args.start_date,
+            interval_hours=args.interval_hours,
+            model_out=args.model_out,
+        )
         return
 
     markets = "h2h,spreads,totals"


### PR DESCRIPTION
## Summary
- add continuous training function in `ml.py`
- expose `continuous_train_classifier` command in CLI
- document how to run the new automatic training mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684320487bb8832ca5593fbcc523bb8e