### PR TITLE
Fix continuous training by requesting game scores

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ def build_historical_odds_url(
     regions: str = "us",
     markets: str = "h2h",
     odds_format: str = "american",
+    include_scores: bool = False,
 ) -> str:
     """Return the fully qualified historical odds API URL."""
     base_url = (
@@ -91,6 +92,8 @@ def build_historical_odds_url(
         "oddsFormat": odds_format,
         "date": date,
     }
+    if include_scores:
+        params["include"] = "scores"
     return f"{base_url}?{urllib.parse.urlencode(params)}"
 
 
@@ -109,6 +112,7 @@ def fetch_historical_odds(
         regions=regions,
         markets=markets,
         odds_format=odds_format,
+        include_scores=True,
     )
     try:
         with urllib.request.urlopen(url) as resp:

--- a/ml.py
+++ b/ml.py
@@ -30,6 +30,7 @@ def build_historical_odds_url(
     regions: str = "us",
     markets: str = "h2h",
     odds_format: str = "american",
+    include_scores: bool = False,
 ) -> str:
     """Return historical odds API URL."""
     base_url = (
@@ -42,6 +43,8 @@ def build_historical_odds_url(
         "oddsFormat": odds_format,
         "date": date,
     }
+    if include_scores:
+        params["include"] = "scores"
     return f"{base_url}?{urllib.parse.urlencode(params)}"
 
 
@@ -60,6 +63,7 @@ def fetch_historical_games(
         regions=regions,
         markets=markets,
         odds_format=odds_format,
+        include_scores=True,
     )
     try:
         with urllib.request.urlopen(url) as resp:


### PR DESCRIPTION
## Summary
- include final scores when hitting the historical odds endpoint

## Testing
- `python3 -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_68433ddacf28832ca43f470642bf0efa