### PR TITLE
Fix historical odds API endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def build_historical_odds_url(
 ) -> str:
     """Return the fully qualified historical odds API URL."""
     base_url = (
-        f"https://api.the-odds-api.com/v4/sports/{sport_key}/odds-history"
+        f"https://api.the-odds-api.com/v4/historical/sports/{sport_key}/odds"
     )
     params = {
         "apiKey": API_KEY,

--- a/ml.py
+++ b/ml.py
@@ -34,7 +34,7 @@ def build_historical_odds_url(
 ) -> str:
     """Return historical odds API URL."""
     base_url = (
-        f"https://api.the-odds-api.com/v4/sports/{sport_key}/odds-history"
+        f"https://api.the-odds-api.com/v4/historical/sports/{sport_key}/odds"
     )
     params = {
         "apiKey": API_KEY,


### PR DESCRIPTION
## Summary
- point ML and CLI tools to the correct historical odds URL

## Testing
- `python3 -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6843407e1de4832c98ccd337e59c1a9a