### PR TITLE
Add debug prints to historical odds fetch

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -135,6 +135,8 @@ def build_dataset_from_api(
                 regions=regions,
                 markets=markets,
             )
+            print(f"Fetched {len(games)} games for {date_str}")
+            print(json.dumps(games[:1], indent=2))
         except ValueError:
             # Skip dates that are outside the API's historical range
             current += timedelta(days=1)


### PR DESCRIPTION
## Summary
- print how many games were fetched per date
- show the first game's JSON for debugging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843464eb23c832c91f1e43d16fa698f