### PR TITLE
Add debug message for parse failures

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -143,7 +143,9 @@ def build_dataset_from_api(
             continue
         for game in games:
             row = _parse_game(game)
-            if row:
+            if not row:
+                print("Skipping game, parse failed:", json.dumps(game, indent=2))
+            else:
                 rows.append(row)
         current += timedelta(days=1)
     if not rows:


### PR DESCRIPTION
## Summary
- log a message when a historical game can't be parsed

## Testing
- `python -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_684347084834832cb0f48f41999869a6