### PR TITLE
Update historical formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -323,7 +323,9 @@ def main() -> None:
             print("No odds found or API returned unexpected data.")
         return
 
-    if args.command in {"moneyline", "historical"}:
+    if args.command == "historical":
+        print(format_moneyline(games))
+    elif args.command == "moneyline":
         print(format_moneyline(games))
     else:
         print(json.dumps(games, indent=2))


### PR DESCRIPTION
## Summary
- show formatted moneyline output when running the `historical` command

## Testing
- `python -m py_compile main.py ml.py`


------
https://chatgpt.com/codex/tasks/task_e_6843678d48b0832c97ca423f138deb03