### PR TITLE
Fix fetch_historical_games data handling

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -73,7 +73,11 @@ def fetch_historical_games(
     )
     try:
         with urllib.request.urlopen(url) as resp:
-            return json.loads(resp.read().decode())
+            data = json.loads(resp.read().decode())
+            # Always extract the "data" key if present
+            if isinstance(data, dict) and "data" in data:
+                return data["data"]
+            return data if isinstance(data, list) else []
     except urllib.error.HTTPError as e:
         message = e.read().decode() if hasattr(e, "read") else str(e)
         try:


### PR DESCRIPTION
## Summary
- update historical odds retrieval to handle nested `data` key

## Testing
- `python -m py_compile ml.py`

------
https://chatgpt.com/codex/tasks/task_e_684368d10054832cab5b0d817b6b545f