### PR TITLE
Improve continuous training start date handling

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -229,10 +229,10 @@ def continuous_train_classifier(
     model_out: str = "moneyline_classifier.pkl",
     verbose: bool = False,
 ) -> None:
+    start_dt = safe_fromisoformat(start_date)
     while True:
         end_dt = datetime.utcnow()
         end_date = end_dt.strftime("%Y-%m-%d")
-        start_dt = safe_fromisoformat(start_date)
         if (end_dt - start_dt).days > MAX_HISTORICAL_DAYS:
             start_dt = end_dt - timedelta(days=MAX_HISTORICAL_DAYS)
         df = build_dataset_from_api(


### PR DESCRIPTION
## Summary
- parse the training start date once before the loop

## Testing
- `python -m py_compile ml.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68436d3ae198832cacb0d250e000d978