### PR TITLE
Use PST iso date when fetching events

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -170,7 +170,7 @@ def build_ks_dataset_from_api(
     rows: list[dict] = []
     current = start
     while current <= end:
-        date_str = current.strftime("%Y-%m-%d")
+        date_str = to_pst_iso8601(current)
         event_ids = fetch_all_event_ids(
             sport_key,
             date=date_str,


### PR DESCRIPTION
## Summary
- use `to_pst_iso8601` when building event requests

## Testing
- `python -m py_compile ml.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68438f736bc4832c9f1fc1abdc324cdd