### PR TITLE
Adjust event fetch timestamp

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -35,10 +35,11 @@ MAX_HISTORICAL_DAYS = 365
 
 # Time helper
 def to_pst_iso8601(date_obj: datetime) -> str:
-    """Return ISO-8601 date string in PST (UTC-8) without DST adjustment."""
+    """Return ISO-8601 date string at 12:00 UTC (``Z``)."""
 
-    # Always use PST (UTC-8), no daylight adjustment
-    return date_obj.strftime("%Y-%m-%dT00:00:00-08:00")
+    # Use a fixed noon UTC timestamp which avoids timezone issues when the API
+    # expects a full ISO 8601 date/time.
+    return date_obj.strftime("%Y-%m-%dT12:00:00Z")
 
 # --------- Simple File Cache -----------#
 


### PR DESCRIPTION
## Summary
- use a noon UTC timestamp when building event fetch dates

## Testing
- `python -m py_compile main.py ml.py`


------
https://chatgpt.com/codex/tasks/task_e_684391995508832caa9001e0f86a52d2