### PR TITLE
Fix projected K odds market

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ def format_projected_ks_props(games: list[dict], model_path: str) -> str:
         for bookmaker in game.get("bookmakers", []):
             bm_title = bookmaker.get("title", bookmaker.get("key", ""))
             for market in bookmaker.get("markets", []):
-                if market.get("key") != "player_strikeouts":
+                if market.get("key") != "batter_strikeouts":
                     continue
                 pitcher_lines: dict[tuple, dict] = {}
                 for outcome in market.get("outcomes", []):


### PR DESCRIPTION
## Summary
- correct the market used to fetch pitcher strikeout props
- update dataset builder to look for `batter_strikeouts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843c4710bbc832ca419df4e43063fd6