### PR TITLE
Add flag to list market keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ pass them via the ``--game-period-markets`` option:
 python main.py --game-period-markets=first_half_totals
 ```
 
+To list all market keys and descriptions available for upcoming games, run:
+
+```bash
+python main.py --list-market-keys
+```
+
 ## Moneyline Classifier
 
 


### PR DESCRIPTION
## Summary
- add --list-market-keys option to CLI
- show unique market keys/descriptions with helper
- document new flag in README

## Testing
- `python -m py_compile main.py ml.py`


------
https://chatgpt.com/codex/tasks/task_e_6843e1213ec4832cb983e017e16b5089