### PR TITLE
Support regions parameter when listing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ To list upcoming events and their IDs for a sport, run:
 ```bash
 python main.py --list-events
 ```
+The region defaults to ``us``. Pass ``--regions`` with a comma-separated list to
+see events available in other regions.
 
 To include game period markets (e.g. quarters or innings) in the API request,
 pass them via the ``--game-period-markets`` option:

--- a/main.py
+++ b/main.py
@@ -54,14 +54,17 @@ def build_odds_url(
     return f"{base}?{urllib.parse.urlencode(params)}"
 
 
-def build_events_url(sport_key: str) -> str:
+def build_events_url(sport_key: str, *, regions: str = "us") -> str:
     """Return the Odds API URL for upcoming events for a sport."""
-    return f"https://api.the-odds-api.com/v4/sports/{sport_key}/events?apiKey={API_KEY}"
+    return (
+        f"https://api.the-odds-api.com/v4/sports/{sport_key}/events"
+        f"?apiKey={API_KEY}&regions={regions}"
+    )
 
 
-def fetch_events(sport_key: str) -> list:
+def fetch_events(sport_key: str, *, regions: str = "us") -> list:
     """Fetch upcoming events for the given sport."""
-    url = build_events_url(sport_key)
+    url = build_events_url(sport_key, regions=regions)
     try:
         with urllib.request.urlopen(url) as resp:
             return json.loads(resp.read().decode())
@@ -394,7 +397,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.list_events:
-        events = fetch_events(args.sport)
+        events = fetch_events(args.sport, regions=args.regions)
         print(json.dumps(events, indent=2))
         return
 


### PR DESCRIPTION
## Summary
- allow specifying regions when listing events
- wire `--regions` flag to `fetch_events`
- document how to override the default region

## Testing
- `python -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e5da3fcc832c9f278fa33536ce75