### PR TITLE
Simplify strikeout projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ run:
 python main.py --model=pitcher_ks_classifier.pkl
 ```
 
-By default the script requests all markets and filters for strikeout props
-locally. Pass the ``--markets`` option to limit the API request to specific
-markets.
+By default the script requests only the ``batter_strikeouts`` market and
+evaluates those props. Pass the ``--markets`` option to request different or
+additional markets.
 
 To display outrights (futures) odds, run:
 


### PR DESCRIPTION
## Summary
- remove H2H printing logic and related CLI flag
- fetch strikeout props from the batter_strikeouts endpoint
- adjust CLI description and defaults
- update README about default markets

## Testing
- `python -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e6c72da4832cbd7d0687c5c2a64f