### PR TITLE
Add event odds endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ python main.py --list-events
 The region defaults to ``us``. Pass ``--regions`` with a comma-separated list to
 see events available in other regions.
 
+To fetch all odds for a single event and print the raw JSON response, supply the
+event ID and ``--event-odds``:
+
+```bash
+python main.py --event-id=<event id> --event-odds
+```
+You can also customize the ``--markets``, ``--odds-format`` and ``--date-format``
+options when using this endpoint.
+
 To include game period markets (e.g. quarters or innings) in the API request,
 pass them via the ``--game-period-markets`` option:
 

--- a/main.py
+++ b/main.py
@@ -114,6 +114,29 @@ def fetch_odds(
         raise RuntimeError(error_msg) from e
 
 
+def fetch_event_odds(
+    sport_key: str,
+    event_id: str,
+    *,
+    regions: str = "us",
+    markets: str = "",
+    odds_format: str = "american",
+    date_format: str = "iso",
+    player_props: bool = True,
+) -> list:
+    """Fetch odds for a specific event using the event odds endpoint."""
+
+    return fetch_odds(
+        sport_key,
+        event_id=event_id,
+        regions=regions,
+        markets=markets,
+        odds_format=odds_format,
+        date_format=date_format,
+        player_props=player_props,
+    )
+
+
 def evaluate_strikeout_props(
     sport_key: str,
     model_path: str,
@@ -313,6 +336,21 @@ def main() -> None:
         help='Specific event ID to fetch odds for (optional)'
     )
     parser.add_argument(
+        '--odds-format',
+        default='american',
+        help='Odds format (default: american)'
+    )
+    parser.add_argument(
+        '--date-format',
+        default='iso',
+        help='Date format for event odds (default: iso)'
+    )
+    parser.add_argument(
+        '--event-odds',
+        action='store_true',
+        help='Display raw odds for a specific event and exit'
+    )
+    parser.add_argument(
         '--player-props',
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -348,6 +386,21 @@ def main() -> None:
                 print(f"{key} - {desc}")
             else:
                 print(key)
+        return
+
+    if args.event_odds:
+        if not args.event_id:
+            parser.error('--event-odds requires --event-id')
+        odds = fetch_event_odds(
+            args.sport,
+            args.event_id,
+            regions=args.regions,
+            markets=args.markets,
+            odds_format=args.odds_format,
+            date_format=args.date_format,
+            player_props=args.player_props,
+        )
+        print(json.dumps(odds, indent=2))
         return
 
     projections = evaluate_strikeout_props(


### PR DESCRIPTION
## Summary
- add `fetch_event_odds` helper
- expose new CLI options for event odds
- print raw event odds when `--event-odds` flag is used
- document how to use the event odds endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install python-dotenv` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6843e951c9cc832cb7368f932d804255