### PR TITLE
Add head-to-head evaluation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ run:
 python main.py --model=pitcher_ks_classifier.pkl
 ```
 
+To display projected head-to-head win probabilities with the moneyline model, run:
+
+```bash
+python main.py --h2h --model=h2h_classifier.pkl
+```
+
 By default the script requests only the ``batter_strikeouts`` market and
 evaluates those props. Pass the ``--markets`` option to request different or
 additional markets.


### PR DESCRIPTION
## Summary
- allow evaluating moneyline win probabilities by adding `--h2h`
- implement `evaluate_h2h_all_tomorrow` and a helper for printing results
- update CLI description and README with new option

## Testing
- `python -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6844052703dc832c94a7088b2bbfd80e