### PR TITLE
Auto create model folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ python main.py alternate_team_totals
 
 The script now focuses solely on head-to-head matchups. Running it without
 extra options will print projected win probabilities using the trained
-``h2h_classifier.pkl`` model:
+``h2h_data/h2h_classifier.pkl`` model. The ``h2h_data`` directory is created
+automatically when training the model:
 
 ```bash
 python main.py

--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from datetime import datetime, timedelta
 import argparse
 
+from ml import H2H_MODEL_PATH
+
 # For improved table and color output
 try:
     from tabulate import tabulate
@@ -351,7 +353,7 @@ def main() -> None:
     )
     parser.add_argument('--sport', default='baseball_mlb', help='Sport key')
     parser.add_argument('--regions', default='us', help='Comma separated regions (default: us)')
-    parser.add_argument('--model', default='h2h_classifier.pkl', help='Path to trained ML model')
+    parser.add_argument('--model', default=str(H2H_MODEL_PATH), help='Path to trained ML model')
     parser.add_argument('--markets', default='h2h', help='Comma separated market keys')
     parser.add_argument('--odds-format', default='american', help='Odds format')
     parser.add_argument('--date-format', default='iso', help='Date format')

--- a/ml.py
+++ b/ml.py
@@ -64,7 +64,10 @@ def _cache_save(cache_dir: Path, key: str, data):
 
 
 H2H_DATA_DIR = ROOT_DIR / "h2h_data"
+H2H_DATA_DIR.mkdir(parents=True, exist_ok=True)
 CACHE_DIR = H2H_DATA_DIR / "api_cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+H2H_MODEL_PATH = H2H_DATA_DIR / "h2h_classifier.pkl"
 
 
 def implied_probability(price: float | int | None) -> float | None:
@@ -499,7 +502,7 @@ def train_h2h_classifier(
     start_date: str,
     end_date: str,
     *,
-    model_out: str = str(H2H_DATA_DIR / "h2h_classifier.pkl"),
+    model_out: str = str(H2H_MODEL_PATH),
     regions: str = "us",
     odds_format: str = "american",
     verbose: bool = False,
@@ -567,7 +570,7 @@ def _cli():
     model_out = args.model_out or (
         "pitcher_ks_classifier.pkl"
         if args.mode == "ks"
-        else str(H2H_DATA_DIR / "h2h_classifier.pkl")
+        else str(H2H_MODEL_PATH)
     )
 
     if args.mode == "h2h":


### PR DESCRIPTION
## Summary
- automatically create `h2h_data` folder on import
- expose `H2H_MODEL_PATH` from `ml.py` and use as the default model for `main.py`
- document new model location

## Testing
- `python -m py_compile main.py ml.py`

------
https://chatgpt.com/codex/tasks/task_e_68440d9e12d0832c898ae6295461637d