### PR TITLE
Improve dataset builder for API format variations

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -208,7 +208,16 @@ def build_h2h_dataset_from_api(
             logger.debug(f"h2h_markets for event_id={event_id}: {h2h_markets}")
             if not h2h_markets:
                 logger.warning(f"No h2h_markets for event_id={event_id} on {date_str}")
-            for book in h2h_markets:
+
+            bookmakers = []
+            if isinstance(h2h_markets, dict) and "data" in h2h_markets and "bookmakers" in h2h_markets["data"]:
+                bookmakers = h2h_markets["data"]["bookmakers"]
+            elif isinstance(h2h_markets, list):
+                bookmakers = h2h_markets
+            elif isinstance(h2h_markets, dict) and "bookmakers" in h2h_markets:
+                bookmakers = h2h_markets["bookmakers"]
+
+            for book in bookmakers:
                 if not isinstance(book, dict):
                     logger.warning(f"Book is not dict: {book}")
                     continue


### PR DESCRIPTION
## Summary
- handle multiple response shapes when building h2h dataset

## Testing
- `python -m py_compile ml.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68441e52a7d8832c8ef16548c76e49db