### PR TITLE
Add verbose debug logs when building dataset

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -197,6 +197,10 @@ def build_h2h_dataset_from_api(
                     price2 = outcomes[1].get("price")
                     result1 = outcomes[0].get("result")
                     result2 = outcomes[1].get("result")
+                    if verbose:
+                        print(
+                            f"DEBUG: {team1} vs {team2} | price1={price1}, price2={price2}, result1={result1}, result2={result2}"
+                        )
                     if None in (team1, team2, price1, price2, result1, result2):
                         continue
                     label = 1 if result1 == "win" else 0


### PR DESCRIPTION
## Summary
- include verbose debug messages in `build_h2h_dataset_from_api`

## Testing
- `python -m py_compile ml.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684470a756cc832c92583dba9421c360