### PR TITLE
Implement simple odds model in ml.py

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -2,6 +2,7 @@ import os
 import json
 import pickle
 import time
+import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
 import urllib.parse
@@ -18,6 +19,18 @@ try:
     from dotenv import load_dotenv
 except ImportError:
     raise ImportError("python-dotenv is required. Install it with 'pip install python-dotenv'")
+
+# Define this class here so it can be unpickled
+class SimpleOddsModel:
+    """A model that converts American odds to implied probability."""
+
+    def predict_proba(self, X):
+        price1 = X["price1"].values[0]
+        if price1 > 0:
+            prob = 100 / (price1 + 100)
+        else:
+            prob = abs(price1) / (abs(price1) + 100)
+        return np.array([[1 - prob, prob]])
 
 ROOT_DIR = Path(__file__).resolve().parent
 DOTENV_PATH = ROOT_DIR / ".env"


### PR DESCRIPTION
## Summary
- add numpy import and SimpleOddsModel class for unpickling saved models
- update ml.py accordingly

## Testing
- `python -m py_compile ml.py main.py train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68449632bfa4832c8a47ea8493238aae