### PR TITLE
Switch to probability-based validation

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -441,7 +441,8 @@ def _train(X: pd.DataFrame, y: pd.Series, model_out: str) -> None:
     )
     model = LogisticRegression(max_iter=1000)
     model.fit(X_train, y_train)
-    preds = model.predict(X_test)
+    probas = model.predict_proba(X_test)[:, 1]
+    preds = (probas >= 0.5).astype(int)
     acc = accuracy_score(y_test, preds)
     print(f"Validation accuracy: {acc:.3f}")
     out_path = Path(model_out)

--- a/train_model.py
+++ b/train_model.py
@@ -195,7 +195,8 @@ def train_from_cache(cache_dir=CACHE_DIR, model_out=H2H_MODEL_PATH, verbose=True
     model = LogisticRegression(max_iter=1000)
     model.fit(X_train, y_train)
 
-    preds = model.predict(X_test)
+    probas = model.predict_proba(X_test)[:, 1]
+    preds = (probas >= 0.5).astype(int)
     acc = accuracy_score(y_test, preds)
     print(f"Model validation accuracy: {acc:.3f}")
 


### PR DESCRIPTION
## Summary
- evaluate classifier validation accuracy using predicted probabilities

## Testing
- `python -m py_compile main.py ml.py train_model.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b5af63ec832cb41e2c0b71ba0b17