### PR TITLE
Add implied probability baseline feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from ml import (
     predict_h2h_probability,
     train_moneyline_classifier,
     predict_moneyline_probability,
+    american_odds_to_prob,
 )
 
 
@@ -287,10 +288,10 @@ def evaluate_h2h_all_tomorrow(
                         continue
                     
                     prob = predict_h2h_probability(model_path, price1, price2)
-                    
+
                     if verbose:
                         print(f"        EVAL: {team1}({price1}) vs {team2}({price2}) prob(team1 win)={prob}")
-                    
+
                     results.append({
                         "game": f"{team1} vs {team2}",
                         "bookmaker": book_name,
@@ -298,6 +299,7 @@ def evaluate_h2h_all_tomorrow(
                         "team2": team2,
                         "price1": price1,
                         "price2": price2,
+                        "implied_team1_win_probability": american_odds_to_prob(price1),
                         "event_id": event_id,
                         "projected_team1_win_probability": prob,
                     })

--- a/ml.py
+++ b/ml.py
@@ -32,6 +32,12 @@ class SimpleOddsModel:
             prob = abs(price1) / (abs(price1) + 100)
         return np.array([[1 - prob, prob]])
 
+def american_odds_to_prob(odds: float) -> float:
+    """Convert American odds to an implied win probability."""
+    if odds > 0:
+        return 100 / (odds + 100)
+    return abs(odds) / (abs(odds) + 100)
+
 ROOT_DIR = Path(__file__).resolve().parent
 DOTENV_PATH = ROOT_DIR / ".env"
 if DOTENV_PATH.exists():
@@ -426,6 +432,7 @@ def build_h2h_dataset_from_api(
                         "team2": team2,
                         "price1": price1,
                         "price2": price2,
+                        "implied_prob": american_odds_to_prob(price1),
                         "team1_win": label,
                     })
                     break

--- a/train_model.py
+++ b/train_model.py
@@ -12,7 +12,7 @@ import json
 
 # Import from your ml.py module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from ml import H2H_DATA_DIR, H2H_MODEL_PATH, CACHE_DIR
+from ml import H2H_DATA_DIR, H2H_MODEL_PATH, CACHE_DIR, american_odds_to_prob
 
 # Define at module level (not inside a function) so it can be pickled
 class SimpleOddsModel:
@@ -161,6 +161,7 @@ def train_from_cache(cache_dir=CACHE_DIR, model_out=H2H_MODEL_PATH, verbose=True
                                     "team2": team2,
                                     "price1": price1,
                                     "price2": price2,
+                                    "implied_prob": american_odds_to_prob(price1),
                                     "team1_win": label,
                                 })
                                 if verbose:


### PR DESCRIPTION
## Summary
- add american_odds_to_prob helper in `ml.py`
- store implied probability when building training datasets
- include implied probability in results for predictions
- export helper so other modules can use it

## Testing
- `python -m py_compile main.py ml.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b8e040f4832c97e9fe26672b8728