### PR TITLE
Filter post-result features

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Columns prefixed with ``pregame_`` are treated as pregame features while those
 starting with ``live_`` are considered live-game inputs. Use the
 ``--features-type`` option of ``train_classifier`` to train on one set or the
 other and avoid mixing the two, which can lead to data leakage.
+Any columns containing terms such as ``result`` or ``final`` are discarded
+automatically to prevent leaking post-game information into the model.
 
 To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 


### PR DESCRIPTION
## Summary
- drop columns with result/final info in `split_feature_sets`
- document that post-game columns are removed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845c0850504832c9efa68d7819136b4