### PR TITLE
Add live inning differential tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ other and avoid mixing the two, which can lead to data leakage.
 Any columns containing terms such as ``result`` or ``final`` are discarded
 automatically to prevent leaking post-game information into the model.
 
+The ``live_features.py`` module introduces an ``InningDifferentialTracker``
+utility for live play. It records the run differential at the end of each
+inning and exposes them as ``live_inning_X_diff`` fields. By updating this
+tracker with live scoring data you can feed time-aware inning-by-inning
+differentials directly into the classifier.
+
 To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 
 ```bash

--- a/live_features.py
+++ b/live_features.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+class InningDifferentialTracker:
+    """Track inning-by-inning run differential with timestamps."""
+
+    def __init__(self) -> None:
+        # Mapping of inning number -> differential (home minus away)
+        self._diff_by_inning: Dict[int, int] = {}
+        # Timestamp of when each inning update was recorded (UTC)
+        self._timestamp_by_inning: Dict[int, datetime] = {}
+
+    def update(self, inning: int, home_runs: int, away_runs: int) -> None:
+        """Update the differential for a completed inning."""
+        diff = home_runs - away_runs
+        self._diff_by_inning[inning] = diff
+        self._timestamp_by_inning[inning] = datetime.utcnow()
+
+    def feature_dict(self) -> Dict[str, int]:
+        """Return feature mapping like {'live_inning_1_diff': 2, ...}."""
+        return {
+            f"live_inning_{inning}_diff": diff
+            for inning, diff in sorted(self._diff_by_inning.items())
+        }
+
+    def cumulative_diff(self) -> int:
+        """Return the cumulative run differential so far."""
+        return sum(self._diff_by_inning.values())


### PR DESCRIPTION
## Summary
- implement `InningDifferentialTracker` for live inning score tracking
- document new live feature in README

## Testing
- `python -m py_compile main.py ml.py train_model.py live_features.py`


------
https://chatgpt.com/codex/tasks/task_e_6845c2e9e55c832c9c2827bd696de06a