### PR TITLE
Add line delta feature for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ endpoint. The dataset should contain a `home_team_win` column as the target
 along with feature columns such as team statistics, starting pitcher ratings,
 bullpen strength, park factor and injury indicators.
 
+If your CSV includes both ``opening_odds`` and ``closing_odds`` columns,
+``train_classifier`` will automatically create a ``line_delta`` feature
+representing ``closing_odds - opening_odds`` so steam moves can be tracked.
+
 Columns prefixed with ``pregame_`` are treated as pregame features while those
 starting with ``live_`` are considered live-game inputs. Use the
 ``--features-type`` option of ``train_classifier`` to train on one set or the

--- a/ml.py
+++ b/ml.py
@@ -47,6 +47,11 @@ def american_odds_to_payout(odds: float) -> float:
         return odds / 100.0
     return 100.0 / abs(odds)
 
+
+def line_movement_delta(closing_odds: float, opening_odds: float) -> float:
+    """Return the change in odds from open to close."""
+    return closing_odds - opening_odds
+
 ROOT_DIR = Path(__file__).resolve().parent
 DOTENV_PATH = ROOT_DIR / ".env"
 if DOTENV_PATH.exists():
@@ -558,6 +563,15 @@ def train_moneyline_classifier(
     df = pd.read_csv(dataset_path)
     if "home_team_win" not in df.columns:
         raise ValueError("Dataset must include 'home_team_win' column")
+
+    # Automatically create a line movement feature if possible
+    if {
+        "opening_odds",
+        "closing_odds",
+    }.issubset(df.columns):
+        df["line_delta"] = df["closing_odds"] - df["opening_odds"]
+        if verbose:
+            print("Computed line_delta column from closing and opening odds")
 
     features_df = df.drop(columns=["home_team_win"])
     pregame_X, live_X = split_feature_sets(features_df)


### PR DESCRIPTION
## Summary
- support auto-computing `line_delta` as the closing minus opening odds
- document new behaviour in the README
- provide helper `line_movement_delta` in `ml.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845c5470a18832c8a6c003adc4163e4