### PR TITLE
Add residuals CSV output after training

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -481,6 +481,16 @@ def _train(X: pd.DataFrame, y: pd.Series, model_out: str) -> None:
     acc = accuracy_score(y_val, preds)
     print(f"Validation accuracy: {acc:.3f}")
 
+    residuals_df = pd.DataFrame({
+        "true_label": y_val.reset_index(drop=True),
+        "model_prob": probas,
+    })
+    residuals_df["residual"] = residuals_df["true_label"] - residuals_df["model_prob"]
+
+    residuals_path = Path(model_out).with_suffix(".residuals.csv")
+    residuals_df.to_csv(residuals_path, index=False)
+    print(f"Residuals saved to {residuals_path}")
+
     out_path = Path(model_out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "wb") as f:

--- a/train_model.py
+++ b/train_model.py
@@ -204,6 +204,15 @@ def train_from_cache(cache_dir=CACHE_DIR, model_out=H2H_MODEL_PATH, verbose=True
     acc = accuracy_score(y_test, preds)
     print(f"Model validation accuracy: {acc:.3f}")
 
+    residuals_df = pd.DataFrame({
+        "true_label": y_test.reset_index(drop=True),
+        "model_prob": probas,
+    })
+    residuals_df["residual"] = residuals_df["true_label"] - residuals_df["model_prob"]
+    residuals_path = model_path.with_suffix(".residuals.csv")
+    residuals_df.to_csv(residuals_path, index=False)
+    print(f"Residuals saved to {residuals_path}")
+
     model_path = Path(model_out)
     model_path.parent.mkdir(parents=True, exist_ok=True)
     with open(model_path, "wb") as f:


### PR DESCRIPTION
## Summary
- add residual computation after training in `ml._train`
- store residuals in train script

## Testing
- `python -m py_compile main.py ml.py train_model.py live_features.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c7ee2b30832cbf4fe5b4adae7e41