### PR TITLE
Apply regression-first strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ endpoint. The dataset should contain a `home_team_win` column as the target
 along with feature columns such as team statistics, starting pitcher ratings,
 bullpen strength, park factor and injury indicators.
 
+While the utility is called a classifier, the model is trained in regression mode to predict a continuous win probability. You can choose any threshold later to convert that score into a binary label.
+
 If your CSV includes both ``opening_odds`` and ``closing_odds`` columns,
 ``train_classifier`` will automatically create a ``line_delta`` feature
 representing ``closing_odds - opening_odds`` so steam moves can be tracked.

--- a/ml.py
+++ b/ml.py
@@ -463,6 +463,7 @@ def _train(X: pd.DataFrame, y: pd.Series, model_out: str) -> None:
     Continuous inputs are standardized using ``StandardScaler`` before
     fitting to improve convergence. Probabilities are calibrated with
     isotonic regression on a validation split.
+    This approach keeps modeling in a regression setup so you can choose any probability threshold later for classification.
     """
 
     X_train, X_val, y_train, y_val = train_test_split(
@@ -569,7 +570,9 @@ def train_moneyline_classifier(
     features_type: str = "pregame",
     verbose: bool = False,
 ) -> None:
-    """Train a logistic regression model from a CSV with a home_team_win column."""
+    """Train a logistic regression model from a CSV with a home_team_win column.
+
+Modeling is done in regression mode first. You can later apply a probability threshold for classification if desired."""
     df = pd.read_csv(dataset_path)
     if "home_team_win" not in df.columns:
         raise ValueError("Dataset must include 'home_team_win' column")


### PR DESCRIPTION
## Summary
- note that the Moneyline classifier is trained in regression mode
- mention classification thresholding in training docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845cb093d8c832c88264e7b63e7f7aa