### PR TITLE
Switch evaluation metrics to AUC/Brier

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ automatically to prevent leaking post-game information into the model.
 
 Continuous numeric features like ERA, SLG and line delta are automatically
 standardized during training to improve optimizer convergence.
+During training, probability quality is reported using AUC and Brier score
+rather than simple accuracy.
 
 The ``live_features.py`` module introduces an ``InningDifferentialTracker``
 utility for live play. It records the run differential at the end of each

--- a/ml.py
+++ b/ml.py
@@ -13,7 +13,7 @@ import hashlib
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_auc_score, brier_score_loss
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import make_pipeline
@@ -478,9 +478,9 @@ def _train(X: pd.DataFrame, y: pd.Series, model_out: str) -> None:
     calibrator.fit(X_val, y_val)
 
     probas = calibrator.predict_proba(X_val)[:, 1]
-    preds = (probas >= 0.5).astype(int)
-    acc = accuracy_score(y_val, preds)
-    print(f"Validation accuracy: {acc:.3f}")
+    auc = roc_auc_score(y_val, probas)
+    brier = brier_score_loss(y_val, probas)
+    print(f"Validation AUC: {auc:.3f}, Brier score: {brier:.3f}")
 
     residuals_df = pd.DataFrame({
         "true_label": y_val.reset_index(drop=True),

--- a/train_model.py
+++ b/train_model.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_auc_score, brier_score_loss
 from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import make_pipeline
 import json
@@ -200,9 +200,9 @@ def train_from_cache(cache_dir=CACHE_DIR, model_out=H2H_MODEL_PATH, verbose=True
     model.fit(X_train, y_train)
 
     probas = model.predict_proba(X_test)[:, 1]
-    preds = (probas >= 0.5).astype(int)
-    acc = accuracy_score(y_test, preds)
-    print(f"Model validation accuracy: {acc:.3f}")
+    auc = roc_auc_score(y_test, probas)
+    brier = brier_score_loss(y_test, probas)
+    print(f"Model validation AUC: {auc:.3f}, Brier score: {brier:.3f}")
 
     residuals_df = pd.DataFrame({
         "true_label": y_test.reset_index(drop=True),


### PR DESCRIPTION
## Summary
- measure probability quality with AUC and Brier score
- mention the evaluation metrics in the docs

## Testing
- `python -m py_compile ml.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6845cc3d0858832c9952ec0d702d5e06