### PR TITLE
Add recency weighting to training

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 python main.py train_classifier --dataset=training_data.csv --features-type=pregame
 ```
 
+Pass ``--recent-half-life`` to weight newer rows more heavily based on a date column
+(defaults to the first column containing ``date`` in its name). Use ``--date-column``
+to specify the exact column if needed.
+
 Or fetch historical data for a date range and train directly from it:
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -538,6 +538,15 @@ def train_classifier_cli(argv: list[str]) -> None:
         help="Which feature set to use for training",
     )
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--recent-half-life",
+        type=float,
+        help="Half-life in days for weighting recent games",
+    )
+    parser.add_argument(
+        "--date-column",
+        help="Column name containing game dates for recency weighting",
+    )
     args = parser.parse_args(argv)
 
     train_moneyline_classifier(
@@ -545,6 +554,8 @@ def train_classifier_cli(argv: list[str]) -> None:
         model_out=args.model_out,
         features_type=args.features_type,
         verbose=args.verbose,
+        recent_half_life=args.recent_half_life,
+        date_column=args.date_column,
     )
 
 


### PR DESCRIPTION
## Summary
- allow weighting more recent games using an exponential half-life
- support weighting in h2h and moneyline training routines
- expose recency options in `train_classifier` CLI
- document new `--recent-half-life` option in README

## Testing
- `python -m py_compile ml.py main.py live_features.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6845eb3998c8832ca5590191651b6baa