### PR TITLE
Separate bankroll logic

### DIFF
--- a/bankroll.py
+++ b/bankroll.py
@@ -1,0 +1,39 @@
+"""Utilities for bankroll management and bet sizing."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ml import american_odds_to_payout
+
+
+def kelly_bet_fraction(prob: float, odds: float) -> float:
+    """Return the Kelly bet fraction for the given probability and American odds."""
+    b = american_odds_to_payout(odds)
+    fraction = (prob * (b + 1) - 1) / b
+    return max(fraction, 0.0)
+
+
+def calculate_bet_size(
+    bankroll: float,
+    prob: float,
+    odds: float,
+    *,
+    fraction: float = 1.0,
+) -> float:
+    """Return recommended stake using Kelly criterion.
+
+    ``fraction`` scales the full Kelly stake (e.g. 0.5 for half-Kelly).
+    """
+    kelly_fraction = kelly_bet_fraction(prob, odds)
+    return bankroll * fraction * kelly_fraction
+
+
+# Simple bankroll update helper
+
+def update_bankroll(bankroll: float, stake: float, result: Literal["win", "loss"], odds: float) -> float:
+    """Return bankroll after applying bet result."""
+    if result == "win":
+        profit = stake * american_odds_to_payout(odds)
+        return bankroll + profit
+    return bankroll - stake

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ from ml import (
     american_odds_to_prob,
     american_odds_to_payout,
 )
+from bankroll import calculate_bet_size
 
 
 def create_simple_fallback_model(model_path):
@@ -425,12 +426,15 @@ def log_bet_recommendations(
     projections: list,
     *,
     threshold: float = 0.0,
+    bankroll: float | None = None,
+    kelly_fraction: float = 1.0,
     log_file: str = "bet_recommendations.log",
 ) -> None:
-    """Append bet recommendations to a log file.
+    """Append bet recommendations to ``log_file``.
 
-    Rows with an implied edge greater than ``threshold`` are written to
-    ``log_file`` with the model probability, offered odds and edge.
+    Rows with an implied edge greater than ``threshold`` are written with the
+    model probability, offered odds and edge. When ``bankroll`` is supplied the
+    recommended stake is calculated using ``calculate_bet_size``.
     """
 
     lines: list[str] = []
@@ -447,6 +451,9 @@ def log_bet_recommendations(
             f"{timestamp} - {team} @ {odds} ({bookmaker}) "
             f"prob={prob:.3f} edge={edge:+.3f}"
         )
+        if bankroll is not None:
+            stake = calculate_bet_size(bankroll, prob, odds, fraction=kelly_fraction)
+            line += f" stake={stake:.2f}"
         lines.append(line)
 
     if not lines:


### PR DESCRIPTION
## Summary
- create `bankroll.py` with bankroll and bet sizing helpers
- use `calculate_bet_size` when logging bet recommendations

## Testing
- `python -m py_compile main.py ml.py live_features.py train_model.py bankroll.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ee5bb57c832cbfcc011fdbf68ea2