### PR TITLE
Add win probability swing tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ model's predicted win probability evolves throughout a game. Supply a list of
 inning scores and the path to your model and it returns timestamped
 probabilities suitable for plotting.
 
+``WinProbabilitySwingTracker`` builds on this by recording the change in win
+probability after each update. It exposes features like
+``win_prob_delta_inning_X`` that capture sharp momentum swings from events such
+as a big inning or pitching change.
+
 To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 
 ```bash

--- a/live_features.py
+++ b/live_features.py
@@ -30,6 +30,54 @@ class InningDifferentialTracker:
         return sum(self._diff_by_inning.values())
 
 
+class WinProbabilitySwingTracker:
+    """Track win probability swings after each inning."""
+
+    def __init__(self, model_path: str, base_features: Dict[str, float] | None = None) -> None:
+        self.model_path = model_path
+        self.base_features = base_features or {}
+        self._diff_tracker = InningDifferentialTracker()
+        self._prob_by_inning: Dict[int, float] = {}
+        self._delta_by_inning: Dict[int, float] = {}
+
+    def update(self, inning: int, home_runs: int, away_runs: int) -> None:
+        """Update win probability using latest score."""
+
+        from ml import predict_moneyline_probability
+
+        self._diff_tracker.update(inning, home_runs, away_runs)
+        features = {**self.base_features, **self._diff_tracker.feature_dict()}
+        prob = predict_moneyline_probability(self.model_path, features)
+        prev_inning = max((i for i in self._prob_by_inning if i < inning), default=None)
+        if prev_inning is None:
+            delta = 0.0
+        else:
+            delta = prob - self._prob_by_inning[prev_inning]
+        self._prob_by_inning[inning] = prob
+        self._delta_by_inning[inning] = delta
+
+    def swing_features(self) -> Dict[str, float]:
+        """Return mapping like {'win_prob_delta_inning_1': -0.05, ...}."""
+
+        return {
+            f"win_prob_delta_inning_{inning}": delta
+            for inning, delta in sorted(self._delta_by_inning.items())
+        }
+
+    def curve(self) -> list[dict]:
+        """Return win probability curve with deltas."""
+
+        return [
+            {
+                "inning": inning,
+                "timestamp": self._diff_tracker._timestamp_by_inning[inning],
+                "probability": prob,
+                "delta": self._delta_by_inning.get(inning, 0.0),
+            }
+            for inning, prob in sorted(self._prob_by_inning.items())
+        ]
+
+
 def build_win_probability_curve(
     model_path: str,
     inning_scores: list[tuple[int, int, int]],


### PR DESCRIPTION
## Summary
- provide WinProbabilitySwingTracker for live win prob deltas
- mention the new tracker in the README

## Testing
- `python -m py_compile bankroll.py bet_logger.py live_features.py ml.py main.py train_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684637f66ec0832cab69dec0344a0fac