### PR TITLE
Implement stale line flag

### DIFF
--- a/bet_logger.py
+++ b/bet_logger.py
@@ -63,6 +63,7 @@ def log_bets(
             "edge": row.get("edge"),
             "weighted_edge": edge,
             "market_disagreement_score": row.get("market_disagreement_score"),
+            "stale_line_flag": row.get("stale_line_flag", False),
             "bookmaker": bookmaker,
             "stake": None,
             "outcome": None,


### PR DESCRIPTION
## Summary
- track last seen moneyline per bookmaker to detect stale lines
- flag stale lines when a book's price lags others by 10+ cents
- amplify weighted edge for flagged lines
- display stale flag in the CLI table output
- record stale_line_flag in bet logs

## Testing
- `python -m py_compile main.py bet_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ebe14498832cb9da93a4447218c0