### PR TITLE
Add managerial text parsing with OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ betting patterns (urgency, insider tone, etc.). This numeric feature can be
 added alongside your regular statistics to capture non-price indicators of
 informed action.
 
+When beat-writer notes or insider chatter are available the
+:func:`attach_managerial_signals` helper can extract tactical cues from the
+text. It uses OpenAI to flag phrases such as "yanked the starter early" or
+"pinch hitter coming for the lefty" and outputs boolean features like
+``early_pull_flag`` and ``pinch_hit_flag``. These signals highlight managerial
+patterns that may influence late-game outcomes beyond the box score.
+
 Set ``REDDIT_CLIENT_ID``/``REDDIT_CLIENT_SECRET`` for Reddit, ``TWITTER_BEARER_TOKEN``
 for Twitter and ``TG_API_ID``/``TG_API_HASH`` for Telegram if you wish to
 enable this feature. ``OPENAI_API_KEY`` must also be configured.


### PR DESCRIPTION
## Summary
- parse text commentary with OpenAI to derive early_pull/pinch_hit flags
- expose `attach_managerial_signals` for datasets
- automatically look for commentary columns when training
- document new NLP features in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ef6a46f8832c9559fa487bcdcd1f