### PR TITLE
Add bullpen ERA vs opponent SLG feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ automatically to prevent leaking post-game information into the model.
 
 Continuous numeric features like ERA, SLG and line delta are automatically
 standardized during training to improve optimizer convergence.
+Another useful metric is ``bullpenERA_vs_opponentSLG`` which subtracts an
+opponent's slugging percentage from a team's bullpen ERA. Include
+``bullpen_ERA`` and ``opponent_SLG_adjusted`` columns in your dataset and the
+trainer will derive this value automatically to highlight volatile late-game
+matchups.
 During training, probability quality is reported using AUC and Brier score
 rather than simple accuracy.
 When live-inning columns are available the validation set is also segmented into


### PR DESCRIPTION
## Summary
- add `bullpen_era_vs_opponent_slg` helper
- compute `bullpenERA_vs_opponentSLG` during training when columns exist
- document the metric in README

## Testing
- `python -m py_compile ml.py live_features.py main.py bet_logger.py bankroll.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f1130764832cbc4ed36ebfede2c2