### PR TITLE
Add dual head classifier training

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ enable this feature. ``OPENAI_API_KEY`` must also be configured.
 Columns prefixed with ``pregame_`` are treated as pregame features while those
 starting with ``live_`` are considered live-game inputs. Use the
 ``--features-type`` option of ``train_classifier`` to train on one set or the
-other and avoid mixing the two, which can lead to data leakage.
+other and avoid mixing the two, which can lead to data leakage. Passing
+``dual`` for this option builds a model with separate heads trained on each
+feature group.
 Any columns containing terms such as ``result`` or ``final`` are discarded
 automatically to prevent leaking post-game information into the model.
 
@@ -200,6 +202,12 @@ To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 
 ```bash
 python main.py train_classifier --dataset=training_data.csv --features-type=pregame
+```
+
+To train both heads at once:
+
+```bash
+python main.py train_classifier --dataset=training_data.csv --features-type=dual
 ```
 
 Pass ``--recent-half-life`` to weight newer rows more heavily based on a date column

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ EDGE_THRESHOLD = 0.06
 from ml import (
     H2H_MODEL_PATH,
     MONEYLINE_MODEL_PATH,
+    train_dual_head_classifier,
     predict_h2h_probability,
     train_moneyline_classifier,
     predict_moneyline_probability,
@@ -677,9 +678,9 @@ def train_classifier_cli(argv: list[str]) -> None:
     parser.add_argument("--model-out", default=str(MONEYLINE_MODEL_PATH))
     parser.add_argument(
         "--features-type",
-        choices=["pregame", "live"],
+        choices=["pregame", "live", "dual"],
         default="pregame",
-        help="Which feature set to use for training",
+        help="Which feature set to use for training (or 'dual' for both)",
     )
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument(
@@ -693,14 +694,23 @@ def train_classifier_cli(argv: list[str]) -> None:
     )
     args = parser.parse_args(argv)
 
-    train_moneyline_classifier(
-        args.dataset,
-        model_out=args.model_out,
-        features_type=args.features_type,
-        verbose=args.verbose,
-        recent_half_life=args.recent_half_life,
-        date_column=args.date_column,
-    )
+    if args.features_type == "dual":
+        train_dual_head_classifier(
+            args.dataset,
+            model_out=args.model_out,
+            verbose=args.verbose,
+            recent_half_life=args.recent_half_life,
+            date_column=args.date_column,
+        )
+    else:
+        train_moneyline_classifier(
+            args.dataset,
+            model_out=args.model_out,
+            features_type=args.features_type,
+            verbose=args.verbose,
+            recent_half_life=args.recent_half_life,
+            date_column=args.date_column,
+        )
 
 
 def predict_classifier_cli(argv: list[str]) -> None:


### PR DESCRIPTION
## Summary
- implement `DualHeadModel` with separate pregame and live heads
- support training via `train_dual_head_classifier`
- expose new `--features-type=dual` option in CLI
- document dual-head training in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684700145554832c979e14f91a8a71db