### PR TITLE
Add bet_freeze_flag when public moves match odds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ cases where the odds move away from the popular side (for example when the line
 shortens on a team receiving fewer bets). Such moves can indicate sharp action
 or internal risk adjustments that the public market has yet to fully price in.
 
+Another derived field ``bet_freeze_flag`` triggers when heavy ticket
+sentiment coincides with a significant line shortening on the same team. This
+safeguard spots potential trap scenarios where books may be encouraging action
+on an overpriced favorite, signaling you to hold off placing the bet.
+
 When Reddit, Twitter or Telegram chatter is accessible the :func:`attach_social_scores`
 helper can derive ``sharp_money_score_social``. It queries recent posts for each
 team and uses OpenAI to rate how closely the language matches historical sharp


### PR DESCRIPTION
## Summary
- introduce `bet_freeze_flag` function in `ml.py`
- compute the new flag during training
- document the feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684705ccf700832cade075965ccc42ae