### PR TITLE
Add volume surge detector module

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ team is reported as ``soft_book_spread`` while their midpoint forms the
 ``multi_book_edge_score``. Large spreads highlight pricing disagreements that
 can be exploited before the books adjust.
 
+When monitoring betting exchanges directly, the ``volume_surge.py`` module
+offers a ``VolumeSurgeDetector`` utility. Provide it with a callback that
+returns the latest matched volume from Betfair or Matchbook and it maintains a
+short rolling history (default 10&nbsp;minutes). If the most recent reading
+exceeds the window average by several standard deviations, the detector outputs
+a ``volume_surge_score`` between 0 and 1. Sudden liquidity spikes often hint at
+syndicates entering the market before prices move.
+
 Set ``REDDIT_CLIENT_ID``/``REDDIT_CLIENT_SECRET`` for Reddit, ``TWITTER_BEARER_TOKEN``
 for Twitter and ``TG_API_ID``/``TG_API_HASH`` for Telegram if you wish to
 enable this feature. ``OPENAI_API_KEY`` must also be configured.

--- a/volume_surge.py
+++ b/volume_surge.py
@@ -1,0 +1,61 @@
+"""
+Utilities for detecting real-time betting volume spikes.
+
+This module provides a ``VolumeSurgeDetector`` that monitors matched volume
+from an exchange via a user-supplied callback and computes a
+``volume_surge_score`` when the latest volume deviates sharply from recent
+history.
+"""
+
+import time
+import statistics
+from collections import deque
+from typing import Callable, Deque, Tuple
+
+class VolumeSurgeDetector:
+    """Track short-term volume spikes on betting exchanges."""
+
+    def __init__(self, fetch_volume: Callable[[], float], *, window_seconds: int = 600, z_threshold: float = 2.0) -> None:
+        """Create detector.
+
+        Parameters
+        ----------
+        fetch_volume:
+            Callable that returns the current matched volume for the market.
+        window_seconds:
+            How many seconds of history to keep for surge calculations.
+        z_threshold:
+            Number of standard deviations above the mean required to flag a surge.
+        """
+        self.fetch_volume = fetch_volume
+        self.window_seconds = window_seconds
+        self.z_threshold = z_threshold
+        self.history: Deque[Tuple[float, float]] = deque()
+
+    def _trim_history(self) -> None:
+        cutoff = time.time() - self.window_seconds
+        while self.history and self.history[0][0] < cutoff:
+            self.history.popleft()
+
+    def update(self) -> float:
+        """Fetch the latest volume and return the current surge score."""
+        volume = self.fetch_volume()
+        self.history.append((time.time(), volume))
+        self._trim_history()
+        return self.volume_surge_score()
+
+    def volume_surge_score(self) -> float:
+        """Return a score from 0-1 indicating abnormal volume."""
+        if len(self.history) < 2:
+            return 0.0
+        volumes = [v for _, v in self.history]
+        avg = statistics.mean(volumes)
+        if len(volumes) > 1:
+            stdev = statistics.stdev(volumes)
+        else:
+            stdev = 0.0
+        if stdev <= 0:
+            return 0.0
+        z = (volumes[-1] - avg) / stdev
+        score = max(0.0, min(1.0, z / self.z_threshold))
+        return score


### PR DESCRIPTION
## Summary
- add `VolumeSurgeDetector` for monitoring real-time betting volume spikes
- document new alt-data signal in README

## Testing
- `python -m py_compile volume_surge.py live_features.py bet_logger.py ml.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68470c5e67e0832cb5fcc578750918dc