### PR TITLE
Add recency weighted features

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ opponent's slugging percentage from a team's bullpen ERA. Include
 ``bullpen_ERA`` and ``opponent_SLG_adjusted`` columns in your dataset and the
 trainer will derive this value automatically to highlight volatile late-game
 matchups.
+If your dataset provides fields like ``stat_last_10`` alongside ``stat``,
+``train_classifier`` will generate ``stat_weighted_recent`` using the
+``--recency-multiplier`` value so recent performance carries more influence.
 During training, probability quality is reported using AUC and Brier score
 rather than simple accuracy.
 When live-inning columns are available the validation set is also segmented into
@@ -253,6 +256,9 @@ python main.py train_classifier --dataset=training_data.csv --features-type=dual
 Pass ``--recent-half-life`` to weight newer rows more heavily based on a date column
 (defaults to the first column containing ``date`` in its name). Use ``--date-column``
 to specify the exact column if needed.
+``--recency-multiplier`` controls how much extra emphasis recent form columns
+receive when paired with season-long averages. A value of ``0.7`` gives 70% weight
+to stats like ``*_last_10`` when creating ``*_weighted_recent`` features.
 
 Or fetch historical data for a date range and train directly from it:
 

--- a/main.py
+++ b/main.py
@@ -757,6 +757,12 @@ def train_classifier_cli(argv: list[str]) -> None:
         help="Half-life in days for weighting recent games",
     )
     parser.add_argument(
+        "--recency-multiplier",
+        type=float,
+        default=0.7,
+        help="Weight to apply to recent stat columns when combining with season averages",
+    )
+    parser.add_argument(
         "--date-column",
         help="Column name containing game dates for recency weighting",
     )
@@ -769,6 +775,7 @@ def train_classifier_cli(argv: list[str]) -> None:
             verbose=args.verbose,
             recent_half_life=args.recent_half_life,
             date_column=args.date_column,
+            recency_multiplier=args.recency_multiplier,
         )
     else:
         train_moneyline_classifier(
@@ -778,6 +785,7 @@ def train_classifier_cli(argv: list[str]) -> None:
             verbose=args.verbose,
             recent_half_life=args.recent_half_life,
             date_column=args.date_column,
+            recency_multiplier=args.recency_multiplier,
         )
 
 


### PR DESCRIPTION
## Summary
- weight recent stats more heavily with `attach_recency_weighted_features`
- expose `--recency-multiplier` in CLI and training helpers
- document how recent metrics are blended

## Testing
- `python -m py_compile main.py ml.py live_features.py bankroll.py bet_logger.py train_model.py volume_surge.py`

------
https://chatgpt.com/codex/tasks/task_e_684712412738832c8f763e830407a2d1