### PR TITLE
Add rolling pressure metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ inning and exposes them as ``live_inning_X_diff`` fields. By updating this
 tracker with live scoring data you can feed time-aware inning-by-inning
 differentials directly into the classifier.
 
+``OffensivePressureTracker`` complements this by keeping rolling counts of
+errors, runners left on base and RISP% over the last two innings. It exposes
+features like ``errors_last_2`` and ``RISP_last_2`` that quantify recent
+pressure or missed opportunities.
+
 The same module provides ``build_win_probability_curve`` to evaluate how the
 model's predicted win probability evolves throughout a game. Supply a list of
 inning scores and the path to your model and it returns timestamped


### PR DESCRIPTION
## Summary
- extend `OffensivePressureTracker` to keep errors and RISP
- expose `errors_last_2`, `LOB_last_2` and `RISP_last_2` features
- support new stats in `WinProbabilitySwingTracker` and `build_win_probability_curve`
- document new tracker in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847142c8550832c8ad0bb10a83af6f8