### PR TITLE
Improve Kelly bet sizing documentation and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,3 +317,15 @@ After the game finishes call ``update_bet_result`` from the ``bet_logger``
 module to mark the bet as a win or loss. The function records the resulting
 payout and the ROI compared to the stake so you can track how profitable the
 model's edge is over time.
+
+## Kelly Bet Sizing
+
+When a bankroll value is supplied, stakes are calculated using the Kelly
+criterion. For a predicted win probability ``p`` and the offered odds expressed
+in decimal form, the fraction of bankroll to wager is::
+
+    kelly_fraction = (b * p - (1 - p)) / b
+
+where ``b`` is ``odds - 1``. This approach allocates more to high-edge plays and
+reduces exposure when the edge is slim. Use the ``kelly_fraction`` argument to
+scale down from full Kelly if desired.

--- a/bankroll.py
+++ b/bankroll.py
@@ -8,9 +8,17 @@ from ml import american_odds_to_payout
 
 
 def kelly_bet_fraction(prob: float, odds: float) -> float:
-    """Return the Kelly bet fraction for the given probability and American odds."""
+    """Return the Kelly bet fraction for a win probability and American odds.
+
+    Implements ``(b * p - q) / b`` where ``b`` is the profit on a $1 bet
+    (decimal odds minus 1), ``p`` is the model probability and ``q`` is
+    ``1 - p``.
+    """
+
     b = american_odds_to_payout(odds)
-    fraction = (prob * (b + 1) - 1) / b
+    p = prob
+    q = 1 - p
+    fraction = (b * p - q) / b
     return max(fraction, 0.0)
 
 


### PR DESCRIPTION
## Summary
- clarify Kelly fraction formula in `bankroll.kelly_bet_fraction`
- document Kelly bet sizing strategy in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847190ea2ac832c9e7ec52aac8776d6