### PR TITLE
Implement risk filter for low-edge moneyline bets

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,3 +329,11 @@ in decimal form, the fraction of bankroll to wager is::
 where ``b`` is ``odds - 1``. This approach allocates more to high-edge plays and
 reduces exposure when the edge is slim. Use the ``kelly_fraction`` argument to
 scale down from full Kelly if desired.
+
+## Risk Filter
+
+To avoid overexposing the bankroll to marginal situations the ``evaluate_h2h``
+logic applies a simple risk filter. Bets with a modeled edge below 5% or
+moneyline odds worse than ``-170`` are assigned a zero weight. They will not be
+logged or factored into weighted edge calculations, helping protect ROI by
+discarding low-value opportunities.

--- a/bet_logger.py
+++ b/bet_logger.py
@@ -43,6 +43,8 @@ def log_bets(
     logs = _load_logs(path)
 
     for row in projections:
+        if row.get("risk_block_flag"):
+            continue
         edge = row.get("weighted_edge", row.get("edge"))
         prob = row.get("projected_team1_win_probability")
         implied = row.get("implied_team1_win_probability")


### PR DESCRIPTION
## Summary
- add risk filter parameters and helper function
- integrate risk-aware weighting into projection evaluation
- skip logging recommendations when bets are blocked
- document new risk filter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68471a351b40832c90c0504bfcf3d1f5