### PR TITLE
Add closing line deviation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,10 @@ bankroll amount is provided the recommended stake is stored as well.
 After the game finishes call ``update_bet_result`` from the ``bet_logger``
 module to mark the bet as a win or loss. The function records the resulting
 payout and the ROI compared to the stake so you can track how profitable the
-model's edge is over time.
+model's edge is over time. When ``closing_odds`` (or ``closing_implied_prob``)
+is supplied, ``update_bet_result`` also stores the closing line's implied
+probability and logs ``deviation_score = predicted_prob - closing_implied_prob``
+to measure how far the model disagreed with the market at close.
 
 ## Kelly Bet Sizing
 


### PR DESCRIPTION
## Summary
- include american_odds_to_prob in bet_logger
- extend `update_bet_result` to store closing implied probability and deviation
- document the new closing-line tracking feature

## Testing
- `pytest -q`
- `python -m py_compile bet_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68471ba159cc832ca1476f68f53909ef