### PR TITLE
Add GPT-based inning trend summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ probability after each update. It exposes features like
 ``win_prob_delta_inning_X`` that capture sharp momentum swings from events such
 as a big inning or pitching change.
 
+``llm_inning_trend_summaries`` complements these utilities by turning raw
+play-by-play logs into a concise ``trend_summary`` for each inning. OpenAI
+distills the pitch sequence and scoring events into one short sentence per
+inning so you can quickly gauge emotional and tactical momentum.
+
 To train the classifier and save it to ``moneyline_classifier.pkl`` run:
 
 ```bash


### PR DESCRIPTION
## Summary
- introduce `llm_inning_trend_summaries` for GPT-driven inning summaries
- document new helper in README

## Testing
- `python -m py_compile bankroll.py bet_logger.py live_features.py ml.py main.py volume_surge.py train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68471e77b568832c998a129233ad4be4