### PR TITLE
Ensure numeric stake values

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,9 @@ allowed by the API.
 
 The project can log recommended bets to ``bet_log.jsonl``. Each entry records
 the team, odds, predicted win probability, the implied probability from the
-odds, the calculated edge and the timestamp when the bet was suggested. When a
-bankroll amount is provided the recommended stake is stored as well.
+odds, the calculated edge and the timestamp when the bet was suggested. The
+stake is stored as a number—``0.0`` when no bankroll is supplied—so later
+results can be evaluated consistently.
 
 After the game finishes call ``update_bet_result`` from the ``bet_logger``
 module to mark the bet as a win or loss. The function records the resulting

--- a/bet_logger.py
+++ b/bet_logger.py
@@ -69,7 +69,8 @@ def log_bets(
     """Append qualifying bet recommendations to ``log_file``.
 
     Each entry records the team, odds, predicted probability, implied probability,
-    edge and optional stake. Outcome fields remain ``null`` until updated
+    edge and a stake amount. When no bankroll is supplied, ``stake`` is ``0.0``.
+    Outcome fields remain ``null`` until updated
     later via :func:`update_bet_result`.
     """
     path = Path(log_file)
@@ -101,7 +102,7 @@ def log_bets(
             "market_maker_mirror_score": row.get("market_maker_mirror_score"),
             "stale_line_flag": row.get("stale_line_flag", False),
             "bookmaker": bookmaker,
-            "stake": None,
+            "stake": 0.0,
             "outcome": None,
             "payout": None,
             "roi": None,


### PR DESCRIPTION
## Summary
- always store numeric `stake` values in bet log
- document that a missing bankroll results in stake=0.0

## Testing
- `python -m py_compile bet_logger.py bankroll.py live_features.py ml.py main.py train_model.py volume_surge.py`

------
https://chatgpt.com/codex/tasks/task_e_684730fb5a88832cae8279159da63fcb