### PR TITLE
Improve bet result validation

### DIFF
--- a/bet_logger.py
+++ b/bet_logger.py
@@ -127,6 +127,9 @@ def update_bet_result(
 ) -> None:
     """Update the log entry for ``event_id`` and ``team`` with ``result``.
 
+    ``result`` must be ``"win"`` or ``"loss"``. Any other value raises
+    ``ValueError`` to prevent silent mistakes.
+
     When ``closing_odds`` or ``closing_implied_prob`` are supplied the function
     records the closing line's implied probability and a ``deviation_score``
     showing how far the model prediction deviated from the market at close.
@@ -142,9 +145,11 @@ def update_bet_result(
             if result == "win":
                 profit = stake * american_odds_to_payout(odds)
                 payout = profit
-            else:
+            elif result == "loss":
                 profit = -stake
                 payout = -stake
+            else:
+                raise ValueError(f"Unknown result '{result}'")
             roi = 0.0
             if stake:
                 roi = profit / stake


### PR DESCRIPTION
## Summary
- validate the `result` argument in `update_bet_result`
- clarify docstring

## Testing
- `python -m py_compile bankroll.py bet_logger.py live_features.py main.py ml.py train_model.py volume_surge.py`


------
https://chatgpt.com/codex/tasks/task_e_6847336bd644832c9755f22a2df13d7f