### PR TITLE
Clarify update_bet_result behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,12 +325,16 @@ stake is stored as a number—``0.0`` when no bankroll is supplied—so later
 results can be evaluated consistently.
 
 After the game finishes call ``update_bet_result`` from the ``bet_logger``
-module to mark the bet as a win or loss. The function records the resulting
-payout and the ROI compared to the stake so you can track how profitable the
-model's edge is over time. When ``closing_odds`` (or ``closing_implied_prob``)
-is supplied, ``update_bet_result`` also stores the closing line's implied
-probability and logs ``deviation_score = predicted_prob - closing_implied_prob``
-to measure how far the model disagreed with the market at close.
+module to mark the bet as a win or loss. ``update_bet_result`` searches for the
+first log entry where ``event_id`` and ``team`` match and ``outcome`` is still
+``null`` and updates that record. If you logged multiple bets for the same
+event/team pair, call the function once for each open position. The function
+records the resulting payout and the ROI compared to the stake so you can track
+how profitable the model's edge is over time. When ``closing_odds`` (or
+``closing_implied_prob``) is supplied, ``update_bet_result`` also stores the
+closing line's implied probability and logs ``deviation_score = predicted_prob -
+closing_implied_prob`` to measure how far the model disagreed with the market at
+close.
 
 ## Kelly Bet Sizing
 

--- a/bet_logger.py
+++ b/bet_logger.py
@@ -127,6 +127,12 @@ def update_bet_result(
 ) -> None:
     """Update the log entry for ``event_id`` and ``team`` with ``result``.
 
+    The function searches the log for the first entry whose ``event_id`` and
+    ``team`` match and whose ``outcome`` is still ``None``. Only this earliest
+    unresolved record is updated. If you log multiple bets for the same
+    event/team combination, call ``update_bet_result`` once for each open
+    position.
+
     ``result`` must be ``"win"`` or ``"loss"``. Any other value raises
     ``ValueError`` to prevent silent mistakes.
 


### PR DESCRIPTION
## Summary
- clarify update_bet_result docs to mention only the first unresolved log entry is updated
- document the same behavior in the README

## Testing
- `python -m py_compile bet_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_684734550dd8832c824c19a8bbfba47b