### PR TITLE
Enable test mode when API key missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This script fetches odds from [The Odds API](https://the-odds-api.com/).
 export THE_ODDS_API_KEY=<your api key>
 ```
 
+If the variable is omitted the script runs in a limited *test mode* without
+making any API requests.
+
 2. Run the script (moneyline odds shown by default):
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -36,8 +36,10 @@ if DOTENV_PATH.exists():
     load_dotenv(DOTENV_PATH)
 
 API_KEY = os.getenv('THE_ODDS_API_KEY')
+TEST_MODE = False
 if not API_KEY:
-    raise RuntimeError('THE_ODDS_API_KEY environment variable is not set')
+    TEST_MODE = True
+    print('THE_ODDS_API_KEY environment variable is not set; running in test mode.')
 
 # Minimum edge required for a bet to be recommended
 EDGE_THRESHOLD = 0.06
@@ -148,6 +150,9 @@ def build_events_url(sport_key: str, regions: str = "us") -> str:
 
 
 def fetch_events(sport_key: str, regions: str = "us") -> list:
+    if TEST_MODE:
+        print("Test mode active: fetch_events returning empty list")
+        return []
     url = build_events_url(sport_key, regions=regions)
     try:
         with urllib.request.urlopen(url) as resp:
@@ -194,6 +199,9 @@ def fetch_event_odds(
     date_format: str = "iso",
     player_props: bool = True,
 ) -> list:
+    if TEST_MODE:
+        print("Test mode active: fetch_event_odds returning empty list")
+        return []
     url = build_event_odds_url(
         sport_key,
         event_id,
@@ -230,6 +238,9 @@ def build_ticket_sentiment_url(event_id: str) -> str:
 
 def fetch_ticket_sentiment(event_id: str) -> Optional[Dict[str, float]]:
     """Return mapping of team -> ticket percentage if available."""
+    if TEST_MODE:
+        print("Test mode active: fetch_ticket_sentiment returning None")
+        return None
 
     url = build_ticket_sentiment_url(event_id)
     try:
@@ -282,7 +293,7 @@ def evaluate_h2h_all_tomorrow(
         print(f"DEBUG: {len(events)} events returned by API")
     
     now = datetime.utcnow()
-    testing_mode = now.year >= 2025
+    testing_mode = TEST_MODE or now.year >= 2025
 
     for event in events:
         commence = event.get("commence_time", "")


### PR DESCRIPTION
## Summary
- allow running `main.py` without an API key by enabling a `TEST_MODE`
- return empty data in `fetch_events`, `fetch_event_odds` and `fetch_ticket_sentiment` when test mode is active
- treat test mode as a signal to bypass the date range restriction
- document new test mode in README

## Testing
- `python -m py_compile main.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68473c5385ec832c8344c5cbbe1e1012