### PR TITLE
Fix build_moneyline_dataset_from_cache dict handling

### DIFF
--- a/data_prep.py
+++ b/data_prep.py
@@ -32,6 +32,13 @@ def build_moneyline_dataset_from_cache(cache_dir: str | Path = DEFAULT_CACHE_DIR
 
         data = cached.get("data") if isinstance(cached, dict) and "data" in cached else cached
 
+        # Some API responses store a single event as a dictionary rather than a
+        # list. Wrap it so the existing iteration logic still works.
+        if isinstance(data, dict):
+            if verbose:
+                print(f"Wrapping single event from {fp.name} into list")
+            data = [data]
+
         if not isinstance(data, list):
             continue
 


### PR DESCRIPTION
## Summary
- handle API cache entries where `data` is a single dict
- log when wrapping a single event for verbose mode

## Testing
- `python3 data_prep.py --cache-dir=test_cache --output=training_data.csv --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68479a333684832c9dc6ec75ded0fa4c