### PR TITLE
Enhance data_prep to handle missing results

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ you can turn those ``.pkl`` files into a training CSV with:
 python3 data_prep.py --output=training_data.csv
 ```
 
+By default, rows without a recorded result are kept with ``team1_win`` set to
+``NaN``. Add the ``--require-results`` flag if you want to filter those out.
+
 The resulting CSV can then be supplied to ``train_classifier`` as shown above.
 
 To predict with a trained model supply feature values as a JSON string:


### PR DESCRIPTION
## Summary
- allow `data_prep` to keep rows without recorded results
- add `--require-results` flag and improve verbose output
- document the new option in the README

## Testing
- `python3 -m py_compile data_prep.py live_features.py main.py ml.py train_model.py bankroll.py bet_logger.py volume_surge.py`

------
https://chatgpt.com/codex/tasks/task_e_68479e8cbe20832cbce9f0840e1d457e