### PR TITLE
Improve cache inspection tool

### DIFF
--- a/data_prep.py
+++ b/data_prep.py
@@ -1,4 +1,6 @@
 import pickle
+import json
+import pprint
 from pathlib import Path
 import pandas as pd
 
@@ -11,6 +13,106 @@ def american_odds_to_prob(odds: float) -> float:
 
 
 DEFAULT_CACHE_DIR = Path("h2h_data") / "api_cache"
+
+
+def examine_cache_structure(cache_dir: str | Path = DEFAULT_CACHE_DIR, max_files: int = 5) -> None:
+    """Print a detailed look at cached API responses for debugging."""
+    cache_path = Path(cache_dir)
+    files = list(cache_path.glob("*.pkl"))
+    if not files:
+        print(f"No cache files found in {cache_path}")
+        return
+
+    print(
+        f"Found {len(files)} cache files. Examining {min(max_files, len(files))} files in detail."
+    )
+
+    for i, file_path in enumerate(files[:max_files]):
+        print(f"\n{'='*80}\nFile {i+1}: {file_path.name}")
+        try:
+            with open(file_path, "rb") as f:
+                data = pickle.load(f)
+
+            if isinstance(data, dict) and "data" in data:
+                print("Structure: Dictionary with 'data' key")
+                other_keys = [k for k in data.keys() if k != "data"]
+                if other_keys:
+                    print(f"Other keys: {other_keys}")
+                inner_data = data["data"]
+                if isinstance(inner_data, list):
+                    print(f"Data: List of {len(inner_data)} events")
+                    events = inner_data
+                elif isinstance(inner_data, dict):
+                    print("Data: Single event dictionary")
+                    events = [inner_data]
+                else:
+                    print(f"Data is of unexpected type: {type(inner_data)}")
+                    continue
+            elif isinstance(data, list):
+                print(f"Structure: Direct list of {len(data)} events")
+                events = data
+            elif isinstance(data, dict):
+                print(f"Structure: Dictionary without 'data' key. Keys: {list(data.keys())}")
+                if "id" in data and "bookmakers" in data:
+                    print("Appears to be a single event")
+                    events = [data]
+                else:
+                    print("Not recognized as event data")
+                    continue
+            else:
+                print(f"Unrecognized data structure: {type(data)}")
+                continue
+
+            if not events:
+                print("No events found in the data")
+                continue
+
+            for event_idx, event in enumerate(events[:2]):
+                print(f"\nExamining Event {event_idx + 1}:")
+                if not isinstance(event, dict):
+                    print(f"Event is not a dictionary: {type(event)}")
+                    continue
+                print(f"Event ID: {event.get('id', 'N/A')}")
+                print(f"Sport: {event.get('sport_key', 'N/A')}")
+                print(f"Teams: {event.get('home_team', 'N/A')} vs {event.get('away_team', 'N/A')}")
+
+                bookmakers = event.get("bookmakers", [])
+                if not bookmakers:
+                    print("No bookmakers found!")
+                    continue
+                print(f"Found {len(bookmakers)} bookmakers")
+                book = bookmakers[0]
+                print(f"First bookmaker: {book.get('key', 'unknown')}")
+                markets = book.get("markets", [])
+                if not markets:
+                    print("No markets found!")
+                    continue
+                print(f"Found {len(markets)} markets")
+                h2h_markets = [m for m in markets if m.get("key") == "h2h"]
+                if not h2h_markets:
+                    print("No h2h markets found!")
+                    continue
+                print(f"Found {len(h2h_markets)} h2h markets")
+                market = h2h_markets[0]
+                outcomes = market.get("outcomes", [])
+                if not outcomes:
+                    print("No outcomes found!")
+                    continue
+                print(f"H2h market has {len(outcomes)} outcomes:")
+                for outcome_idx, outcome in enumerate(outcomes):
+                    print(f"\n  Outcome {outcome_idx + 1}:")
+                    print(f"    Name: {outcome.get('name', 'N/A')}")
+                    print(f"    Price: {outcome.get('price', 'N/A')}")
+                    print(f"    Result: {outcome.get('result', 'N/A')}")
+                    print(f"    All fields: {list(outcome.keys())}")
+
+                print("\nFull event structure:")
+                try:
+                    print(json.dumps(event, indent=2, default=str)[:500] + "...")
+                except Exception:
+                    pprint.pprint(event)
+        except Exception as e:
+            print(f"Error examining file {file_path}: {e}")
 
 
 def build_moneyline_dataset_from_cache(
@@ -124,14 +226,26 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Convert cached API pickles to a training CSV")
     parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR), help="Directory containing .pkl cache files")
-    parser.add_argument("--output", required=True, help="Path to write the CSV dataset")
+    parser.add_argument("--output", help="Path to write the CSV dataset")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument(
         "--require-results",
         action="store_true",
         help="Only include entries with result fields",
     )
+    parser.add_argument(
+        "--examine-cache",
+        action="store_true",
+        help="Print information about cached files and exit",
+    )
     args = parser.parse_args()
+
+    if args.examine_cache:
+        examine_cache_structure(args.cache_dir)
+        raise SystemExit(0)
+
+    if not args.output:
+        parser.error("--output is required unless --examine-cache is used")
 
     try:
         save_dataset_from_cache(


### PR DESCRIPTION
## Summary
- add detailed cache inspector to `data_prep.py`
- allow `--examine-cache` CLI flag and make `--output` optional when examining

## Testing
- `python -m py_compile data_prep.py`
- `python data_prep.py --examine-cache`
- `python data_prep.py --cache-dir h2h_data/api_cache --output dataset.csv` *(fails: No cache files found in h2h_data/api_cache)*

------
https://chatgpt.com/codex/tasks/task_e_6847a07e5538832c8fadbe90ba79059b