### PR TITLE
Add scores endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,31 @@ year. If the supplied ``--start-date`` is older than that window, the
 continuous training command automatically clamps it to the most recent date
 allowed by the API.
 
+To record live and recent scores for training data, fetch them using the ``scores`` command:
+
+```bash
+python3 main.py scores --sport=baseball_mlb --days-from=1 --save-history
+```
+
+This saves the latest results to ``h2h_data/scores_history.jsonl`` which can later
+be converted into a training dataset.
+
+To keep a dataset-driven model up to date, run the moneyline continuous training
+command. It retrains from the specified CSV on a fixed interval and also records
+recent scores:
+
+```bash
+python3 main.py continuous_train_moneyline --dataset=training_data.csv \
+    --interval-hours=24 --sport=baseball_mlb
+```
+
+Likewise the market maker mirror model can be refreshed automatically:
+
+```bash
+python3 main.py continuous_train_mirror --dataset=training_data.csv \
+    --interval-hours=24 --sport=baseball_mlb
+```
+
 ## Bet Logging
 
 The project can log recommended bets to ``bet_log.jsonl``. Each entry records

--- a/scores.py
+++ b/scores.py
@@ -1,0 +1,48 @@
+import os
+import json
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from datetime import datetime
+
+API_KEY = os.getenv("THE_ODDS_API_KEY")
+SCORES_HISTORY_FILE = Path("h2h_data") / "scores_history.jsonl"
+
+
+def build_scores_url(sport_key: str, days_from: int = 0, date_format: str = "iso") -> str:
+    """Return API URL for the scores endpoint."""
+    base = f"https://api.the-odds-api.com/v4/sports/{sport_key}/scores/"
+    params = {"apiKey": API_KEY}
+    if days_from:
+        params["daysFrom"] = str(days_from)
+    if date_format:
+        params["dateFormat"] = date_format
+    return f"{base}?{urllib.parse.urlencode(params)}"
+
+
+def fetch_scores(sport_key: str, days_from: int = 0, date_format: str = "iso") -> list:
+    """Fetch upcoming, live and recent scores for ``sport_key``."""
+    if not API_KEY:
+        print("THE_ODDS_API_KEY environment variable is not set; cannot fetch scores")
+        return []
+    url = build_scores_url(sport_key, days_from=days_from, date_format=date_format)
+    try:
+        with urllib.request.urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:  # pragma: no cover - network error handling
+        print(f"Error fetching scores: {exc}")
+        return []
+
+
+def append_scores_history(scores: list, path: Path = SCORES_HISTORY_FILE) -> None:
+    """Append ``scores`` to ``path`` as JSON lines with a timestamp."""
+    if not scores:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().isoformat()
+    with open(path, "a") as f:
+        for game in scores:
+            record = {"timestamp": timestamp, **game}
+            json.dump(record, f)
+            f.write("\n")
+


### PR DESCRIPTION
## Summary
- add `scores.py` helper to fetch and save recent game scores
- integrate score fetching and continuous training into `main.py`
- document how to record scores in README
- add continuous training for dataset models

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847a4f6607c832cafe34e8e24afef73