### PR TITLE
Fix dataset column compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The project includes a simple logistic regression model that predicts the
 probability of the home team winning a matchup. Training data can be supplied
 via a CSV file **or** gathered automatically using the Odds API historical odds
 endpoint. The dataset should contain a `home_team_win` column as the target
+(datasets generated with `data_prep.py` use `team1_win`, which is also accepted)
 along with feature columns such as team statistics, starting pitcher ratings,
 bullpen strength, park factor and injury indicators.
 
@@ -319,7 +320,8 @@ python3 data_prep.py --output=training_data.csv
 ```
 
 By default, rows without a recorded result are kept with ``team1_win`` set to
-``NaN``. Add the ``--require-results`` flag if you want to filter those out.
+``NaN``. This column is treated as ``home_team_win`` when training.
+Add the ``--require-results`` flag if you want to filter those out.
 
 The resulting CSV can then be supplied to ``train_classifier`` as shown above.
 

--- a/ml.py
+++ b/ml.py
@@ -1237,7 +1237,11 @@ Modeling is done in regression mode first. You can later apply a probability thr
     with memory_usage("read_csv") if profile_memory else nullcontext():
         df = pd.read_csv(dataset_path)
     if "home_team_win" not in df.columns:
-        raise ValueError("Dataset must include 'home_team_win' column")
+        # Older datasets produced by data_prep.py used 'team1_win'
+        if "team1_win" in df.columns:
+            df = df.rename(columns={"team1_win": "home_team_win"})
+        else:
+            raise ValueError("Dataset must include 'home_team_win' column")
 
     # Automatically create line movement features when possible
     if {"opening_odds", "closing_odds"}.issubset(df.columns):
@@ -1374,7 +1378,10 @@ def train_dual_head_classifier(
     with memory_usage("read_csv") if profile_memory else nullcontext():
         df = pd.read_csv(dataset_path)
     if "home_team_win" not in df.columns:
-        raise ValueError("Dataset must include 'home_team_win' column")
+        if "team1_win" in df.columns:
+            df = df.rename(columns={"team1_win": "home_team_win"})
+        else:
+            raise ValueError("Dataset must include 'home_team_win' column")
 
     attach_recency_weighted_features(df, multiplier=recency_multiplier, verbose=verbose)
 


### PR DESCRIPTION
## Summary
- support legacy `team1_win` dataset column when training models
- clarify README about `team1_win` vs `home_team_win`

## Testing
- `python3 -m py_compile ml.py data_prep.py main.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ba64d314832c99ca03d8448d28fc