### PR TITLE
Fix training with datasets containing strings

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1040,6 +1040,9 @@ def _train(
 
     model_out = sanitize_path(model_out)
 
+    # Ensure training data only contains numeric columns
+    X = pd.DataFrame(X).select_dtypes(include=[np.number, bool]).fillna(0)
+
     ctx = memory_usage("train_split") if profile_memory else nullcontext()
     with ctx:
         if sample_weight is not None:
@@ -1324,7 +1327,7 @@ Modeling is done in regression mode first. You can later apply a probability thr
     # Blend recent form metrics with season-long stats
     attach_recency_weighted_features(df, multiplier=recency_multiplier, verbose=verbose)
 
-    features_df = df.drop(columns=["home_team_win"])
+    features_df = df.drop(columns=["home_team_win"]).select_dtypes(include=[np.number, bool]).fillna(0)
     pregame_X, live_X = split_feature_sets(features_df)
     X = live_X if features_type == "live" else pregame_X
     y = df["home_team_win"]
@@ -1385,7 +1388,7 @@ def train_dual_head_classifier(
 
     attach_recency_weighted_features(df, multiplier=recency_multiplier, verbose=verbose)
 
-    features_df = df.drop(columns=["home_team_win"])
+    features_df = df.drop(columns=["home_team_win"]).select_dtypes(include=[np.number, bool]).fillna(0)
     pregame_X, live_X = split_feature_sets(features_df)
     y = df["home_team_win"]
     if verbose:


### PR DESCRIPTION
## Summary
- ensure model training drops non-numeric columns
- sanitize features for dual-head classifier
- sanitize features for single-head moneyline classifier

## Testing
- `python3 -m py_compile ml.py main.py data_prep.py bankroll.py bet_logger.py live_features.py scores.py train_model.py volume_surge.py update_cache_scores.py`

------
https://chatgpt.com/codex/tasks/task_e_6847bbcfa004832c9b34ea35c5d25910