### PR TITLE
Fix training error with missing labels

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1043,6 +1043,14 @@ def _train(
     # Ensure training data only contains numeric columns
     X = pd.DataFrame(X).select_dtypes(include=[np.number, bool]).fillna(0)
 
+    # Remove rows where the target is missing
+    mask = pd.Series(y).notna()
+    if mask.sum() != len(y):
+        X = X.loc[mask]
+        y = pd.Series(y)[mask]
+        if sample_weight is not None:
+            sample_weight = pd.Series(sample_weight)[mask]
+
     ctx = memory_usage("train_split") if profile_memory else nullcontext()
     with ctx:
         if sample_weight is not None:


### PR DESCRIPTION
## Summary
- handle rows with missing labels in `_train`

## Testing
- `python3 -m py_compile ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6847bd5d8e04832c9f0ccf493704c560