### PR TITLE
Handle empty training data before splitting

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1051,6 +1051,12 @@ def _train(
         if sample_weight is not None:
             sample_weight = pd.Series(sample_weight)[mask]
 
+    if len(X) == 0:
+        raise ValueError(
+            "Training data is empty after preprocessing. "
+            "Check that the dataset contains numeric feature values and non-missing labels."
+        )
+
     ctx = memory_usage("train_split") if profile_memory else nullcontext()
     with ctx:
         if sample_weight is not None:


### PR DESCRIPTION
## Summary
- raise a clear exception if the training set becomes empty after preprocessing

## Testing
- `python -m py_compile ml.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6847c1b09bb0832ca7c9aa3a811e2920