### PR TITLE
Clarify Retrosheet TXT input

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ python3 integrate_data.py
 
 If you only need the Retrosheet results without any odds data, run
 ``process_retrosheet.py``. It downloads the last several seasons and produces
-``retrosheet_training_data.csv`` with rolling team stats and synthetic odds:
+``retrosheet_training_data.csv`` with rolling team stats and synthetic odds.
+The Retrosheet ZIP archives contain fixed-width ``GLYYYY.TXT`` files, so the
+script parses those text logs directly and writes the combined results to CSV:
 
 ```bash
 python3 process_retrosheet.py

--- a/integrate_data.py
+++ b/integrate_data.py
@@ -2,6 +2,7 @@
 import os
 import pandas as pd
 import zipfile
+# Retrosheet provides game logs as fixed-width text files inside ZIP archives.
 import requests
 import pickle
 from pathlib import Path
@@ -153,7 +154,7 @@ def download_retrosheet_data(year):
         return None
 
 def extract_zip_file(zip_path):
-    """Extract files from retrosheet ZIP file"""
+    """Extract the GL####.TXT log from a Retrosheet ZIP archive"""
     if not zip_path or not zip_path.exists():
         return None
     
@@ -174,7 +175,7 @@ def extract_zip_file(zip_path):
         return None
 
 def parse_retrosheet_file(file_path, year):
-    """Parse Retrosheet game log file"""
+    """Parse a GL####.TXT game log and return a dataframe"""
     if not file_path or not file_path.exists():
         return None
     

--- a/process_retrosheet.py
+++ b/process_retrosheet.py
@@ -2,6 +2,9 @@
 import os
 import pandas as pd
 import zipfile
+# Retrosheet archives contain fixed-width text files (GL####.TXT).
+# This script extracts those TXT files and converts them into a CSV suitable
+# for model training.
 import requests
 from pathlib import Path
 from datetime import datetime
@@ -42,7 +45,7 @@ def download_retrosheet_data(year):
 
 
 def extract_zip_file(zip_path):
-    """Extract files from retrosheet ZIP file"""
+    """Extract the GL####.TXT log from a Retrosheet ZIP archive"""
     if not zip_path or not zip_path.exists():
         return None
     try:
@@ -93,7 +96,7 @@ FIELD_SPECS = [
 
 
 def parse_retrosheet_file(file_path, year):
-    """Parse Retrosheet game log file"""
+    """Parse a GL####.TXT game log and return a dataframe"""
     if not file_path or not file_path.exists():
         return None
 


### PR DESCRIPTION
## Summary
- document that Retrosheet archives contain fixed-width TXT files
- update comments in Retrosheet processing scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847e9789178832caddfa12903ddaf82