### PR TITLE
Fix odds history API request parameters

### DIFF
--- a/process_retrosheet.py
+++ b/process_retrosheet.py
@@ -84,12 +84,17 @@ def fetch_odds_for_date(date: str) -> list:
     if not API_KEY:
         print(f"No API key, skipping odds for {date}")
         return []
-    url = (
-        "https://api.the-odds-api.com/v4/sports/baseball_mlb/odds-history"
-        f"/?apiKey={API_KEY}&regions=us&markets=h2h&date={date}"
-    )
+    url = "https://api.the-odds-api.com/v4/sports/baseball_mlb/odds-history"
+    params = {
+        "apiKey": API_KEY,
+        "regions": "us",
+        "markets": "h2h",
+        "dateFormat": "iso",
+        "oddsFormat": "american",
+        "date": date,
+    }
     try:
-        resp = requests.get(url, timeout=30)
+        resp = requests.get(url, params=params, timeout=30)
         if resp.ok:
             cache_file.write_text(resp.text)
             return resp.json()


### PR DESCRIPTION
## Summary
- add date and odds format params when requesting historical odds

## Testing
- `python3 -m py_compile process_retrosheet.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848689ad908832ca1467d22200ffa2c