### PR TITLE
Improve historical data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ python3 main.py historical --date=2024-01-01
 ```
 
 Historical data is only available for approximately the last year.
+When training with ``ml.py`` any start date older than this window is
+automatically adjusted to the earliest supported day to avoid empty results.
 
 The script requests head-to-head, point spread, totals, and outright markets as
 needed. It prints


### PR DESCRIPTION
## Summary
- clamp historical data start date to API window in `ml.py`
- clarify README regarding the historical data limit

## Testing
- `python3 -m py_compile ml.py main.py process_retrosheet.py integrate_data.py bankroll.py bet_logger.py live_features.py data_prep.py scores.py train_model.py update_cache_scores.py volume_surge.py`
- `python3 -m pip install -q -r requirements.txt`
- `python3 -m pip install -q -r requirements-dev.txt`


------
https://chatgpt.com/codex/tasks/task_e_6848745369fc832c8359feb6eb27e6c5