### PR TITLE
Remove fallback odds model

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,23 @@ python3 main.py alternate_team_totals
 ```
 
 The script now focuses solely on head-to-head matchups. Running it without
-extra options will print projected win probabilities using the trained
-``h2h_data/h2h_classifier.pkl`` model. The ``h2h_data`` directory is created
-automatically when training the model:
+extra options prints projected win probabilities using a trained
+``h2h_data/h2h_classifier.pkl`` model. Be sure to train the classifier first —
+otherwise the script will exit with an error. The ``h2h_data`` directory is
+created automatically when training:
 
 ```bash
 python3 main.py
 ```
 
 Use ``--model`` to specify a different classifier file if needed.
+
+If you previously generated a simple fallback model, delete that file and train
+a classifier instead:
+
+```bash
+python3 main.py train_classifier --dataset=retrosheet_training_data.csv
+```
 
 To display outrights (futures) odds, run:
 

--- a/main.py
+++ b/main.py
@@ -177,41 +177,13 @@ def risk_filter(edge: float | None, odds: float | None) -> float:
     return 1.0
 
 
-def create_simple_fallback_model(model_path):
-    """Create a simple model that directly converts odds to probabilities without ML"""
-    print(f"{Fore.YELLOW}No trained model found at {model_path}" if Fore else f"No trained model found at {model_path}")
-    print("Creating a simple fallback model based on American odds conversion...")
-
-    class SimpleOddsModel:
-        def predict_proba(self, X):
-            price1 = X['price1'].values[0]
-            if price1 > 0:
-                prob = 100 / (price1 + 100)
-            else:
-                prob = abs(price1) / (abs(price1) + 100)
-            return np.array([[1 - prob, prob]])
-
-    model = SimpleOddsModel()
-
-    model_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(model_path, 'wb') as f:
-        pickle.dump(model, f)
-
-    print(f"{Fore.GREEN}Simple fallback model created at {model_path}" if Fore else f"Simple fallback model created at {model_path}")
-    print("Note: This is a very basic model based on odds conversion. For better results, train with real data:")
-    print(
-        "python ml.py --sport baseball_mlb --start-date 2023-05-01 "
-        "--end-date 2023-06-01 --verbose"
-    )
-
-    return model
-
-
 def ensure_model_exists(model_path):
-    """Ensure a model file exists, creating a fallback if needed."""
+    """Return the path if a trained model exists or raise an error."""
     path = Path(model_path)
     if not path.exists():
-        create_simple_fallback_model(path)
+        raise FileNotFoundError(
+            f"No trained model found at {path}. Train one with 'python3 main.py train_classifier'"
+        )
     return str(path)
 
 

--- a/ml.py
+++ b/ml.py
@@ -1232,7 +1232,12 @@ def predict_h2h_probability(
 ) -> float:
     model_path = sanitize_path(model_path)
     with open(model_path, "rb") as f:
-        model = pickle.load(f)
+        try:
+            model = pickle.load(f)
+        except AttributeError as exc:
+            raise RuntimeError(
+                "Invalid or outdated model file. Train a new classifier using 'python3 main.py train_classifier'."
+            ) from exc
     df = pd.DataFrame([{"price1": price1, "price2": price2}])
     proba = model.predict_proba(df)[0][1]
     return float(proba)


### PR DESCRIPTION
## Summary
- remove SimpleOddsModel fallback logic
- error when no trained model is present
- document that a trained model is required before running `main.py`
- clarify that old fallback model files must be replaced
- fail gracefully if old fallback model is loaded

## Testing
- `python3 -m py_compile main.py ml.py live_features.py bankroll.py bet_logger.py scores.py data_prep.py integrate_data.py process_retrosheet.py train_model.py update_cache_scores.py volume_surge.py`


------
https://chatgpt.com/codex/tasks/task_e_68487661d23c832c83813f3fba45e5ad