### PR TITLE
Unify training and live inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ export THE_ODDS_API_KEY=<your api key>
 If the variable is omitted the script runs in a limited *test mode* without
 making any API requests.
 
+### Quick start
+
+To fetch live odds, compute all features and output today's bet recommendations:
+
+```bash
+python3 main.py --run
+```
+
+This command pulls the latest odds, computes every feature and prints a
+dashboard with the top edges. Results are also saved to ``bet_log.jsonl`` and
+``bet_recommendations.log``.
+
+To build datasets and retrain the models in one step (example years shown):
+
+```bash
+python3 main.py --train --years 2018-2024
+```
+
+The old subcommands remain available for advanced workflows but ``--run`` and
+``--train`` are the recommended one-click options.
+
 2. Run the script (moneyline odds shown by default):
 
 ```bash


### PR DESCRIPTION
## Summary
- refactor `main.py` to parse `--run` and `--train` directly
- show a simple dashboard of top bets from `_summarize_projections`
- document the one-click options in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684890f0496c832c847b05fbd7f58d59