### PR TITLE
Add warning when prediction columns missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ python3 main.py predict_classifier --features='{"home_team_stat":1.2,"away_team_
 
 The command prints the home team win probability.
 
+Training column names are persisted in the ``.pkl`` file. Prediction helpers
+reindex the provided feature mapping to this saved order, filling any missing
+columns with ``0``. A warning is emitted when expected columns are absent so
+mismatches can be caught early.
+
 To keep the classifier up to date without manually running a command each time,
 use the continuous training mode. This repeatedly fetches historical data from a
 start date up to the current day and retrains the model on a fixed interval

--- a/ml.py
+++ b/ml.py
@@ -2,6 +2,7 @@ import os
 import json
 import pickle
 import time
+import warnings
 import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -1280,6 +1281,12 @@ def predict_h2h_probability(
 
     df = pd.DataFrame([{"price1": price1, "price2": price2}])
     if cols is not None:
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            warnings.warn(
+                f"Missing feature columns: {', '.join(missing)}",
+                RuntimeWarning,
+            )
         df = df.reindex(cols, axis=1, fill_value=0)
 
     proba = model.predict_proba(df)[0][1]
@@ -1655,6 +1662,12 @@ def predict_moneyline_probability(
 
     df = pd.DataFrame([features])
     if cols is not None:
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            warnings.warn(
+                f"Missing feature columns: {', '.join(missing)}",
+                RuntimeWarning,
+            )
         df = df.reindex(cols, axis=1, fill_value=0)
 
     proba = model.predict_proba(df)[0][1]

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -1,0 +1,34 @@
+import pickle
+import warnings
+from pathlib import Path
+
+import ml
+
+
+def _save_dummy_model(path: Path) -> None:
+    model = ml.SimpleOddsModel()
+    cols = ["price1", "foo"]
+    with open(path, "wb") as f:
+        pickle.dump((model, cols), f)
+
+
+def test_predict_moneyline_matching(tmp_path):
+    path = tmp_path / "model.pkl"
+    _save_dummy_model(path)
+    features = {"price1": 150, "foo": 1.0}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("error")
+        prob = ml.predict_moneyline_probability(str(path), features)
+    assert prob == 100 / (150 + 100)
+    assert not w
+
+
+def test_predict_moneyline_missing(tmp_path):
+    path = tmp_path / "model.pkl"
+    _save_dummy_model(path)
+    features = {"price1": -110}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        prob = ml.predict_moneyline_probability(str(path), features)
+    assert any("Missing feature columns" in str(msg.message) for msg in w)
+    assert abs(prob - (110 / 210)) < 1e-6


### PR DESCRIPTION
## Summary
- warn if expected columns are missing when predicting
- document feature reindexing in README
- add regression tests for reindexing behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b1cbd3d8832c8ba67152a4f7957f