### PR TITLE
Improve progress logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,3 +486,17 @@ Training functions in ``ml.py`` accept a ``profile_memory`` flag. When set to
 heavy pandas operations and model fitting is printed to the console. This can
 help identify bottlenecks when working with large datasets.
 
+## Verbose Output and Debugging
+
+Pass the ``--verbose`` flag to ``main.py`` to see progress messages while data
+is fetched and evaluated. This prints a short notice for each game as odds are
+retrieved. For interactive troubleshooting launch the script with Python's
+built-in debugger:
+
+```bash
+python3 -m pdb main.py --verbose
+```
+
+The debugger lets you inspect variables, step through code and continue
+execution at your own pace.
+

--- a/main.py
+++ b/main.py
@@ -398,11 +398,14 @@ def evaluate_h2h_all_tomorrow(
             start_dt = datetime(today.year, today.month, today.day, 16, 0, 0)
             end_dt = start_dt + timedelta(hours=14)
 
-            if not (start_dt <= commence_dt < end_dt):
-                if verbose:
-                    print(f"  Skipped: commence_time {commence_dt} not in window {start_dt} to {end_dt}")
-                continue
+        if not (start_dt <= commence_dt < end_dt):
+            if verbose:
+                print(f"  Skipped: commence_time {commence_dt} not in window {start_dt} to {end_dt}")
+            continue
 
+        if verbose:
+            msg = f"[FETCHING] Odds for {away} at {home} ({event_id})..."
+            print(msg, end="", flush=True)
         game_odds = fetch_event_odds(
             sport_key,
             event_id,
@@ -410,6 +413,9 @@ def evaluate_h2h_all_tomorrow(
             regions=regions,
             player_props=False,
         )
+
+        if verbose:
+            print(" done.")
         
         if verbose:
             print(f"  Raw odds for event {event_id}:")


### PR DESCRIPTION
## Summary
- display when each event's odds are fetched
- document verbose output and debugging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684941f00ff0832c9d3fbae36020795d