### PR TITLE
Improve fallback logs in fix_numeric_conversion

### DIFF
--- a/fix_numeric_conversion.py
+++ b/fix_numeric_conversion.py
@@ -68,18 +68,19 @@ def extract_advanced_ml_features(
             prob = predict_moneyline_probability(model_path, features)
         except Exception as e:
             # Fallback to simple implied probability if model fails
-            print(f"Using fallback probability calculation")
+            print(f"Using fallback probability calculation: {e}")  # PATCH: Log error for easier debugging
             prob = implied + 0.02  # Slight edge over implied
 
         edge = prob - implied
         ev = edge * american_odds_to_payout(price1)
+        print(f"Model prob: {prob:.4f}, Implied: {implied:.4f}, Edge: {edge:.4f}")  # PATCH: Log edge calculation
 
         return {
             "ml_confidence": prob,
             "lineup_strength": 0.5,  # Default value
             "market_efficiency": implied,
             "sharp_action": edge,
-            "advanced_ml_prob": prob, 
+            "advanced_ml_prob": prob,
             "advanced_ml_edge": edge,
             "advanced_ml_ev": ev,
         }


### PR DESCRIPTION
## Summary
- add debug information when model prediction fails
- log probability/edge calculations for troubleshooting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c30c0644832c9b81a4ae4c3e3455