### PR TITLE
Add warning for zero edge

### DIFF
--- a/fix_numeric_conversion.py
+++ b/fix_numeric_conversion.py
@@ -72,6 +72,8 @@ def extract_advanced_ml_features(
             prob = implied + 0.02  # Slight edge over implied
 
         edge = prob - implied
+        if abs(edge) < 1e-6:
+            print("WARNING: Edge is zero or near zero. Check model and input features!")  # PATCH: Diagnostic
         ev = edge * american_odds_to_payout(price1)
         print(f"Model prob: {prob:.4f}, Implied: {implied:.4f}, Edge: {edge:.4f}")  # PATCH: Log edge calculation
 


### PR DESCRIPTION
## Summary
- warn when calculated edge is zero or nearly zero in fix_numeric_conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c924d708832c882e9d60c131a9a1