### PR TITLE
Fix predict_h2h_probability debug output

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1327,7 +1327,9 @@ def predict_h2h_probability(
         df = df.reindex(cols, axis=1, fill_value=0)
 
     proba = model.predict_proba(df)[0][1]
-    print(f"[DEBUG] Model proba: {proba} (features: {features})")
+    print(
+        f"[DEBUG] Model proba: {proba} (price1: {price1}, price2: {price2})"
+    )
     return float(proba)
 
 


### PR DESCRIPTION
## Summary
- log prices in `predict_h2h_probability` instead of an undefined variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849eb8480a4832c985981888ddae09f