### PR TITLE
Implement simple training and prediction helpers

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -2,24 +2,35 @@ import pandas as pd
 from sklearn.linear_model import LogisticRegression
 import pickle
 
-# MVP: strict minimal feature set, no fallback logic
+# Functions only; no code at global scope except imports and definitions.
 
-# 1. TRAINING PHASE
+def train_mvp_model(csv_path: str, model_path: str) -> None:
+    """Train a logistic regression model and persist it to ``model_path``."""
+    df = pd.read_csv(csv_path)
+    required_cols = ["price1", "price2", "home_team_win"]
 
-df = pd.read_csv("retrosheet_training_data.csv")
-X = df[["price1", "price2"]]
-y = df["home_team_win"]
-model = LogisticRegression()
-model.fit(X, y)
+    # Strict: fail if columns missing
+    missing = set(required_cols) - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
 
-with open("mvp_model.pkl", "wb") as f:
-    pickle.dump(model, f)
+    X = df[["price1", "price2"]]
+    y = df["home_team_win"]
 
-# 2. PREDICTION PHASE (example)
-with open("mvp_model.pkl", "rb") as f:
-    model = pickle.load(f)
+    model = LogisticRegression()
+    model.fit(X, y)
 
-# Predict for a new game (replace with real data)
-new_game = pd.DataFrame([{"price1": -120, "price2": 110}])
-win_prob = model.predict_proba(new_game)[:, 1][0]
-print("Win probability:", win_prob)
+    with open(model_path, "wb") as f:
+        pickle.dump(model, f)
+
+def predict_mvp(model_path: str, price1: float, price2: float) -> float:
+    """Return the predicted home win probability for the given prices."""
+    with open(model_path, "rb") as f:
+        model = pickle.load(f)
+    X_pred = pd.DataFrame([{"price1": price1, "price2": price2}])
+    return model.predict_proba(X_pred)[:, 1][0]
+
+# Usage example (commented out; use in your CLI or pipeline)
+# train_mvp_model("retrosheet_training_data.csv", "mvp_model.pkl")
+# prob = predict_mvp("mvp_model.pkl", -120, 110)
+# print("Win probability:", prob)


### PR DESCRIPTION
## Summary
- implement logistic regression train/predict helpers in `ml.py`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'H2H_MODEL_PATH' from ml)*

------
https://chatgpt.com/codex/tasks/task_e_684a566e1a00832ca4407ad5e86d6991