### PR TITLE
Integrate MVP ML patch

### DIFF
--- a/bankroll.py
+++ b/bankroll.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Literal
 
-from ml import american_odds_to_payout
+def american_odds_to_payout(odds: float) -> float:
+    """Return the profit on a $1 bet for the given American odds."""
+    if odds > 0:
+        return odds / 100.0
+    return 100.0 / abs(odds)
 
 
 def kelly_bet_fraction(prob: float, odds: float) -> float:

--- a/bet_logger.py
+++ b/bet_logger.py
@@ -14,7 +14,20 @@ else:  # pragma: no cover - POSIX
     import fcntl
 
 from bankroll import calculate_bet_size
-from ml import american_odds_to_payout, american_odds_to_prob
+
+
+def american_odds_to_payout(odds: float) -> float:
+    """Return the profit on a $1 bet for the given American odds."""
+    if odds > 0:
+        return odds / 100.0
+    return 100.0 / abs(odds)
+
+
+def american_odds_to_prob(odds: float) -> float:
+    """Convert American odds to an implied win probability."""
+    if odds > 0:
+        return 100 / (odds + 100)
+    return abs(odds) / (abs(odds) + 100)
 
 
 def _load_logs(path: Path) -> list[dict]:

--- a/main.py
+++ b/main.py
@@ -62,22 +62,7 @@ def should_highlight_row(edge: float | None) -> bool:
 SOFT_BOOKS = ("bovada", "mybookie", "betus")
 
 # Import here to avoid circular imports
-from ml import (
-    H2H_MODEL_PATH,
-    MONEYLINE_MODEL_PATH,
-    train_h2h_classifier,
-    train_dual_head_classifier,
-    predict_h2h_probability,
-    train_moneyline_classifier,
-    predict_moneyline_probability,
-    american_odds_to_prob,
-    american_odds_to_payout,
-    MARKET_MAKER_MIRROR_MODEL_PATH,
-    train_market_maker_mirror_model,
-    market_maker_mirror_score,
-    extract_advanced_ml_features,
-    extract_market_signals,
-)
+from ml import H2H_MODEL_PATH
 import ml
 from bankroll import calculate_bet_size
 from bet_logger import log_bets


### PR DESCRIPTION
## Summary
- set `H2H_MODEL_PATH` constant for logistic model
- add American odds helpers and minimal ML prediction utilities
- inline odds helpers in `bet_logger` and `bankroll`
- trim `main` imports to match simplified ML module

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a58edcea4832cbfb3b2beffbfdb06