### PR TITLE
Add mirror model training csv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,32 @@ shift. Train the model with ``train_market_maker_mirror_model`` on a dataset
 containing opening/closing odds plus handle and ticket percentages. The model
 predicts a synthetic closing price representing what a highly efficient book
 would offer. Comparing that price to the current line yields the
+
 ``market_maker_mirror_score``—positive values suggest the market line is longer
 than the mirrored price while negative values indicate shading.
+
+To train the mirror model provide a CSV with these columns:
+
+| Column Name    | Description                                                | Example |
+| -------------- | ---------------------------------------------------------- | ------- |
+| opening_odds   | The opening moneyline odds for the team                   | -110    |
+| closing_odds   | The closing moneyline odds for the team                   | -130    |
+| handle_percent | Percentage of money wagered on the team (0-100 float)     | 62.5    |
+| ticket_percent | Percentage of tickets/wagers on the team (0-100 float)    | 70.0    |
+| volatility     | (Optional) Line movement or volatility metric             | 15.0    |
+| mirror_target  | Target variable for mirror model (e.g., 0 or 1)           | 1       |
+
+Example:
+
+```csv
+opening_odds,closing_odds,handle_percent,ticket_percent,volatility,mirror_target
+-110,-130,62.5,70.0,15.0,1
++120,+105,38.0,29.0,8.0,0
+```
+
+All columns except ``volatility`` are required. ``mirror_target`` serves as the
+training target and percentages must be floats between 0 and 100. When columns
+are missing the trainer raises ``ValueError: Missing required columns...``.
 
 When monitoring betting exchanges directly, the ``volume_surge.py`` module
 offers a ``VolumeSurgeDetector`` utility. Provide it with a callback that
@@ -435,8 +459,8 @@ python3 main.py continuous_train_moneyline --dataset=training_data.csv \
 Likewise the market maker mirror model can be refreshed automatically:
 
 ```bash
-python3 main.py continuous_train_mirror --dataset=training_data.csv \
-    --interval-hours=24 --sport=baseball_mlb
+python3 main.py continuous_train_mirror --dataset=mirror_training_data.csv \
+    --interval-hours=24 --sport=baseball_mlb --verbose
 ```
 
 ## Bet Logging


### PR DESCRIPTION
## Summary
- document required CSV columns for the mirror model
- show example training dataset and update continuous training command

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a86d21bcc832ca44208192fd85d05