### PR TITLE
Implement validation for mirror trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Likewise the market maker mirror model can be refreshed automatically:
 
 ```bash
 python3 main.py continuous_train_mirror --dataset=mirror_training_data.csv \
-    --interval-hours=24 --sport=baseball_mlb --verbose
+    --interval=24 --verbose
 ```
 
 ## Bet Logging


### PR DESCRIPTION
## Summary
- validate dataset columns before repeatedly training the mirror model
- update README usage example for the mirror trainer

## Testing
- `pip install -q -r requirements.txt && pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a88cec5e4832c9318f8e874590e77