### PR TITLE
Enforce distinct handle and ticket percents

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,6 +103,8 @@ K_PROJECTED_WIN = "projected_team1_win_probability"
 K_EDGE = "edge"
 K_PAYOUT = "payout"
 K_EXPECTED_VALUE = "expected_value"
+K_HANDLE_PCT_TEAM1 = "handle_percent_team1"
+K_HANDLE_PCT_TEAM2 = "handle_percent_team2"
 K_TICKET_PCT_TEAM1 = "ticket_percent_team1"
 K_TICKET_PCT_TEAM2 = "ticket_percent_team2"
 K_PUBLIC_FADE = "public_fade"
@@ -130,6 +132,8 @@ class ProjectionRow(TypedDict, total=False):
     edge: float
     payout: float
     expected_value: float
+    handle_percent_team1: float | None
+    handle_percent_team2: float | None
     ticket_percent_team1: float
     ticket_percent_team2: float
     public_fade: bool
@@ -548,6 +552,8 @@ def evaluate_h2h_all_tomorrow(
                 team2 = outcome2.get("name")
                 price1 = outcome1.get("price")
                 price2 = outcome2.get("price")
+                handle1 = outcome1.get("handle_percentage")
+                handle2 = outcome2.get("handle_percentage")
 
                 if team1 is None or team2 is None or price1 is None or price2 is None:
                     if verbose:
@@ -602,6 +608,8 @@ def evaluate_h2h_all_tomorrow(
                     K_EDGE: edge,
                     K_PAYOUT: payout,
                     K_EXPECTED_VALUE: ev,
+                    K_HANDLE_PCT_TEAM1: handle1,
+                    K_HANDLE_PCT_TEAM2: handle2,
                     K_TICKET_PCT_TEAM1: team1_pct,
                     K_TICKET_PCT_TEAM2: team2_pct,
                     K_PUBLIC_FADE: fade,
@@ -639,8 +647,8 @@ def evaluate_h2h_all_tomorrow(
             row[K_MULTI_BOOK_EDGE_SCORE] = multi_book_edge
             mm_features = {
                 "opening_odds": row.get(K_PRICE1),
-                "handle_percent": row.get(K_TICKET_PCT_TEAM1, 0.0),
-                "ticket_percent": row.get(K_TICKET_PCT_TEAM1, 0.0),
+                "handle_percent": row.get(K_HANDLE_PCT_TEAM1),
+                "ticket_percent": row.get(K_TICKET_PCT_TEAM1),
                 "volatility": diff * 100,
             }
             if Path(MARKET_MAKER_MIRROR_MODEL_PATH).exists():
@@ -670,7 +678,8 @@ def evaluate_h2h_all_tomorrow(
                 sig = extract_market_signals(
                     model_path=str(MARKET_MAKER_MIRROR_MODEL_PATH),
                     price1=row.get(K_PRICE1),
-                    ticket_percent=row.get(K_TICKET_PCT_TEAM1, 0.0),
+                    handle_percent=row.get(K_HANDLE_PCT_TEAM1),
+                    ticket_percent=row.get(K_TICKET_PCT_TEAM1),
                 )
                 row.update(sig)
             weight = 1 + diff + (soft_spread or 0)

--- a/ml.py
+++ b/ml.py
@@ -99,15 +99,27 @@ def extract_market_signals(
     model_path: str,
     *,
     price1: float,
-    ticket_percent: float,
+    handle_percent: float | None,
+    ticket_percent: float | None,
 ) -> dict:
     """Return simple market maker mirror metrics for the given line."""
+    if handle_percent is None:
+        raise ValueError(
+            "handle_percent is missing in event data. "
+            "Do not use ticket_percent as a fallback. "
+            "The dataset must contain independent handle and ticket percentages."
+        )
+    if ticket_percent is None:
+        raise ValueError(
+            "ticket_percent is missing in event data. "
+            "Both handle_percent and ticket_percent must be present."
+        )
     with open(model_path, "rb") as f:
         model = pickle.load(f)
     df = pd.DataFrame([
         {
             "opening_odds": price1,
-            "handle_percent": ticket_percent,
+            "handle_percent": handle_percent,
             "ticket_percent": ticket_percent,
             "volatility": 0.0,
         }

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -70,7 +70,7 @@ def test_extract_market_signals(tmp_path):
     model_path = tmp_path / "mirror.pkl"
     _save_dummy_mirror_model(model_path)
     feats = ml.extract_market_signals(
-        str(model_path), price1=150, ticket_percent=60.0
+        str(model_path), price1=150, handle_percent=55.0, ticket_percent=60.0
     )
     assert "predicted_mirror_price" in feats
     assert "mirror_score" in feats


### PR DESCRIPTION
## Summary
- require handle_percent in `extract_market_signals`
- track handle percentages alongside ticket percentages in evaluation
- update unit tests for new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a89aa13d4832ca9a398161eb07c71