### PR TITLE
Fix cache dir import

### DIFF
--- a/update_cache_scores.py
+++ b/update_cache_scores.py
@@ -4,7 +4,7 @@ import pickle
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from ml import CACHE_DIR
+from data_prep import DEFAULT_CACHE_DIR as CACHE_DIR
 from scores import fetch_scores, append_scores_history
 
 


### PR DESCRIPTION
## Summary
- use DEFAULT_CACHE_DIR from `data_prep` in `update_cache_scores.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a950ebcbc832c9fff40cd749612cb