### PR TITLE
Handle string result values in mirror training dataset

### DIFF
--- a/generate_mirror_training_data.py
+++ b/generate_mirror_training_data.py
@@ -51,7 +51,8 @@ def extract_row(event, book, market, home_team, away_team):
         if team_result is None:
             continue
 
-        mirror_target = 1 if team_result == 1 else 0
+        # Interpret string results ("win"/"loss") as mirror_target
+        mirror_target = 1 if str(team_result).lower() == "win" else 0
 
         return {
             "opening_odds": opening_odds,


### PR DESCRIPTION
## Summary
- interpret 'win'/'loss' strings in the cached data when generating mirror model training rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a960b7f68832c86050cfeca7b9bad