### PR TITLE
Integrate simplified mirror model

### DIFF
--- a/main.py
+++ b/main.py
@@ -663,12 +663,7 @@ def evaluate_h2h_all_tomorrow(
 
             # Add market maker mirror signals
             if Path(MARKET_MAKER_MIRROR_MODEL_PATH).exists():
-                sig = extract_market_signals(
-                    model_path=str(MARKET_MAKER_MIRROR_MODEL_PATH),
-                    price1=row.get(K_PRICE1),
-                    handle_percent=row.get(K_HANDLE_PCT_TEAM1),
-                    ticket_percent=row.get(K_TICKET_PCT_TEAM1),
-                )
+                sig = extract_market_signals(row)
                 row.update(sig)
             weight = 1 + diff + (soft_spread or 0)
             if row.get(K_STALE_FLAG):
@@ -1307,7 +1302,7 @@ def continuous_train_mirror_cli(argv: list[str]) -> None:
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args(argv)
 
-    required_columns = ["opening_odds", "handle_percent", "ticket_percent", "mirror_target"]
+    required_columns = ["opening_odds", "closing_odds", "volatility", "mirror_target"]
     try:
         df = pd.read_csv(args.dataset, nrows=1)
     except Exception as e:

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -46,14 +46,6 @@ def test_predict_moneyline_missing(tmp_path):
     assert abs(prob - (110 / 210 + 0.02)) < 1e-6
 
 
-class DummyMirrorModel:
-    def predict(self, X):
-        return X["opening_odds"].values + 10
-
-
-def _save_dummy_mirror_model(path: Path) -> None:
-    with open(path, "wb") as f:
-        pickle.dump(DummyMirrorModel(), f)
 
 
 def test_extract_advanced_ml_features(tmp_path):
@@ -67,11 +59,8 @@ def test_extract_advanced_ml_features(tmp_path):
 
 
 def test_extract_market_signals(tmp_path):
-    model_path = tmp_path / "mirror.pkl"
-    _save_dummy_mirror_model(model_path)
-    feats = ml.extract_market_signals(
-        str(model_path), price1=150, handle_percent=55.0, ticket_percent=60.0
-    )
-    assert "predicted_mirror_price" in feats
-    assert "mirror_score" in feats
+    event = {"opening_price": 150, "volatility": 5.0}
+    feats = ml.extract_market_signals(event)
+    assert feats["opening_odds"] == 150
+    assert feats["volatility"] == 5.0
 


### PR DESCRIPTION
## Summary
- replace market maker mirror training function with simplified version
- update feature extraction for mirror model
- adjust main program for new signal extractor
- update tests for new interface

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b20e42abc832ca1c478fb8c009eea