### PR TITLE
Add line movement feature utilities

### DIFF
--- a/line_movement_features.py
+++ b/line_movement_features.py
@@ -1,0 +1,70 @@
+"""Line movement detection utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+
+def detect_steam_moves(
+    df: pd.DataFrame,
+    sportsbook_cols: list[str],
+    *,
+    window_seconds: int = 600,
+    min_books: int = 3,
+    move_threshold: float = 0.5,
+) -> pd.Series:
+    """Return a flag for steam moves within ``window_seconds``."""
+
+    steam_flags = np.zeros(len(df), dtype=int)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    for i in range(1, len(df)):
+        t_now = df.loc[i, "timestamp"]
+        t_window = t_now - pd.Timedelta(seconds=window_seconds)
+        mask = (df["timestamp"] >= t_window) & (df["timestamp"] < t_now)
+        moves = []
+        for col in sportsbook_cols:
+            prev = df.loc[mask, col].dropna()
+            if not prev.empty:
+                last_val = prev.iloc[-1]
+                change = df.loc[i, col] - last_val
+                if abs(change) >= move_threshold:
+                    moves.append(np.sign(change))
+        if len(moves) >= min_books and (abs(sum(moves)) == len(moves)):
+            steam_flags[i] = 1
+    return pd.Series(steam_flags, index=df.index, name="steam_move")
+
+
+def calculate_rlm(
+    df: pd.DataFrame,
+    consensus_col: str,
+    line_col: str,
+    public_side_col: str,
+) -> pd.Series:
+    """Return a reverse line movement flag."""
+
+    line_change = df[line_col] - df[consensus_col]
+    rlm = (
+        ((df[public_side_col] == 1) & (line_change < 0))
+        | ((df[public_side_col] == 0) & (line_change > 0))
+    ).astype(int)
+    return pd.Series(rlm, index=df.index, name="reverse_line_move")
+
+
+def add_line_movement_context_features(
+    df: pd.DataFrame,
+    sportsbook_cols: list[str],
+    opening_line_col: str,
+    last_move_time_col: str,
+) -> pd.DataFrame:
+    """Add contextual line movement features."""
+
+    df["net_line_change"] = df[sportsbook_cols].mean(axis=1) - df[opening_line_col]
+    df["time_since_last_move"] = (
+        df["timestamp"] - df[last_move_time_col]
+    ).dt.total_seconds()
+    threshold = 0.5
+    recent_moves = (df[sportsbook_cols].diff().abs() > threshold).sum(axis=1)
+    df["num_books_moved"] = recent_moves
+    df["magnitude_recent_moves"] = df[sportsbook_cols].diff().abs().sum(axis=1)
+    return df

--- a/tests/test_line_movement_features.py
+++ b/tests/test_line_movement_features.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from line_movement_features import (
+    detect_steam_moves,
+    calculate_rlm,
+    add_line_movement_context_features,
+)
+
+
+def test_detect_steam_moves_basic():
+    now = pd.Timestamp.utcnow()
+    data = {
+        "timestamp": [now + timedelta(seconds=i * 300) for i in range(4)],
+        "book1": [100, 101, 102, 102],
+        "book2": [100, 101, 102, 102],
+        "book3": [100, 101, 102, 102],
+    }
+    df = pd.DataFrame(data)
+    flags = detect_steam_moves(df, ["book1", "book2", "book3"], window_seconds=600)
+    assert flags.iloc[2] == 1
+    assert flags.sum() == 2
+
+
+def test_calculate_rlm():
+    df = pd.DataFrame(
+        {
+            "consensus": [100, 100, 100],
+            "current": [99, 101, 100],
+            "public": [1, 0, 1],
+        }
+    )
+    rlm = calculate_rlm(df, "consensus", "current", "public")
+    assert list(rlm) == [1, 1, 0]
+
+
+def test_add_line_movement_context_features():
+    now = pd.Timestamp.utcnow()
+    df = pd.DataFrame(
+        {
+            "timestamp": [now, now + timedelta(seconds=60)],
+            "open": [100, 100],
+            "last_move": [now - timedelta(seconds=30), now],
+            "book1": [100, 100.6],
+            "book2": [100, 100.4],
+        }
+    )
+    result = add_line_movement_context_features(
+        df.copy(), ["book1", "book2"], "open", "last_move"
+    )
+    assert "net_line_change" in result
+    assert "num_books_moved" in result
+    assert result.loc[1, "num_books_moved"] == 1


### PR DESCRIPTION
## Summary
- add line movement detection helpers
- test steam move, reverse line move, and context features

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b589cdd1c832c8b4ff0838921f0d2