### PR TITLE
Add compute_odds_volatility

### DIFF
--- a/tests/test_line_movement_features.py
+++ b/tests/test_line_movement_features.py
@@ -11,6 +11,7 @@ from line_movement_features import (
     detect_steam_moves,
     calculate_rlm,
     add_line_movement_context_features,
+    compute_odds_volatility,
 )
 
 
@@ -57,3 +58,39 @@ def test_add_line_movement_context_features():
     assert "net_line_change" in result
     assert "num_books_moved" in result
     assert result.loc[1, "num_books_moved"] == 1
+
+
+def test_compute_odds_volatility_basic():
+    now = pd.Timestamp.utcnow()
+    df = pd.DataFrame(
+        {
+            "timestamp": [now, now + timedelta(seconds=60), now + timedelta(seconds=120)],
+            "p1": [100, 110, 120],
+            "p2": [200, 200, 200],
+        }
+    )
+    result = compute_odds_volatility(
+        df, ["p1", "p2"], window_seconds=120, min_periods=2
+    )
+    assert "volatility_p1" in result
+    assert "volatility_p2" in result
+    assert np.isnan(result.loc[0, "volatility_p1"])
+    assert abs(result.loc[1, "volatility_p1"] - 7.0710678118654755) < 1e-6
+    assert abs(result.loc[2, "volatility_p1"] - 7.0710678118654755) < 1e-6
+    assert result.loc[1, "volatility_p2"] == 0.0
+    assert result.loc[2, "volatility_p2"] == 0.0
+
+
+def test_compute_odds_volatility_count_changes():
+    now = pd.Timestamp.utcnow()
+    df = pd.DataFrame(
+        {
+            "timestamp": [now, now + timedelta(seconds=60), now + timedelta(seconds=120)],
+            "p1": [100, 110, 120],
+        }
+    )
+    result = compute_odds_volatility(
+        df, ["p1"], window_seconds=120, count_changes=True
+    )
+    assert "changes_p1" in result
+    assert list(result["changes_p1"]) == [1.0, 2.0, 2.0]


### PR DESCRIPTION
## Summary
- implement `compute_odds_volatility` in `line_movement_features.py`
- test odds volatility calculation and change counting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5cce4a10832ca14a6462d029b8ff