### PR TITLE
Add pricing pressure utilities

### DIFF
--- a/pricing_pressure.py
+++ b/pricing_pressure.py
@@ -1,0 +1,41 @@
+"""Pricing pressure utilities."""
+
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+
+def price_momentum(df: pd.DataFrame, col: str, window_seconds: int = 3600) -> pd.Series:
+    """Return price change over the past ``window_seconds``."""
+    df = df.sort_values('timestamp').reset_index(drop=True)
+    shifted = df['timestamp'] - pd.Timedelta(seconds=window_seconds)
+    df_window = df[['timestamp', col]].copy()
+    df_window.columns = ['window_start', 'window_price']
+    merged = pd.merge_asof(
+        df[['timestamp', col]],
+        df_window,
+        left_on='timestamp',
+        right_on='window_start',
+        direction='backward'
+    )
+    momentum = df[col] - merged['window_price']
+    momentum.name = f"momentum_{col}"
+    return momentum
+
+
+def price_acceleration(df: pd.DataFrame, col: str, window_seconds: int = 3600) -> pd.Series:
+    """Return the difference in momentum over time."""
+    momentum = price_momentum(df, col, window_seconds)
+    acceleration = momentum.diff()
+    acceleration.name = f"acceleration_{col}"
+    return acceleration
+
+
+def cross_book_disparity(df: pd.DataFrame, sharp_col: str, other_cols: list[str]) -> pd.Series:
+    """Return disparity between ``sharp_col`` and the mean of ``other_cols``."""
+    others_mean = df[other_cols].mean(axis=1)
+    disparity = df[sharp_col] - others_mean
+    disparity.name = f"disparity_{sharp_col}_vs_others"
+    return disparity

--- a/tests/test_pricing_pressure.py
+++ b/tests/test_pricing_pressure.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from pricing_pressure import (
+    price_momentum,
+    price_acceleration,
+    cross_book_disparity,
+)
+
+
+def test_price_momentum_and_acceleration():
+    times = pd.date_range("2021-01-01", periods=3, freq="H")
+    df = pd.DataFrame({"timestamp": times, "price": [100, 105, 110]})
+    momentum = price_momentum(df, "price", window_seconds=3600)
+    acceleration = price_acceleration(df, "price", window_seconds=3600)
+    assert list(momentum) == [0, 0, 0]
+    assert list(acceleration) == [None, 0, 0]
+
+
+def test_cross_book_disparity():
+    times = pd.date_range("2021-01-01", periods=3, freq="H")
+    df = pd.DataFrame(
+        {
+            "timestamp": times,
+            "sharp": [100, 105, 110],
+            "book1": [99, 103, 108],
+            "book2": [101, 104, 109],
+        }
+    )
+    disparity = cross_book_disparity(df, "sharp", ["book1", "book2"])
+    assert list(disparity) == [0.0, 1.5, 1.5]


### PR DESCRIPTION
## Summary
- implement `pricing_pressure` module
- add tests for new pricing pressure calculations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684be4331b40832c952d0479ce92385a