### PR TITLE
Add pricing pressure features to market maker event

### DIFF
--- a/pricing_pressure.py
+++ b/pricing_pressure.py
@@ -28,7 +28,9 @@ def price_momentum(df: pd.DataFrame, col: str, window_seconds: int = 3600) -> pd
 def price_acceleration(df: pd.DataFrame, col: str, window_seconds: int = 3600) -> pd.Series:
     """Return the difference in momentum over time."""
     momentum = price_momentum(df, col, window_seconds)
-    acceleration = momentum.diff()
+    acceleration = momentum.diff().astype(object)
+    if not acceleration.empty:
+        acceleration.iloc[0] = None
     acceleration.name = f"acceleration_{col}"
     return acceleration
 


### PR DESCRIPTION
## Summary
- import pricing pressure utilities
- extend market maker event with volatility, momentum, acceleration, and disparity metrics
- ensure `price_acceleration` outputs `None` for the first row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1b57f4a0832c8611e82f9c342b6c