### PR TITLE
Add liquidity metrics utilities

### DIFF
--- a/liquidity_metrics.py
+++ b/liquidity_metrics.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import numpy as np
+
+
+def line_adjustment_rate(df: pd.DataFrame, col: str, *, window_seconds: int = 3600) -> pd.Series:
+    """Return the rate of price changes per ``window_seconds`` for ``col``."""
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    price_changes = df[col].ne(df[col].shift())
+    series = price_changes.copy()
+    series.index = df["timestamp"]
+    roll = series.rolling(f"{window_seconds}s", min_periods=1).sum().reset_index(drop=True)
+    rate = roll / (window_seconds / 3600)
+    rate.name = f"line_adjustment_rate_{col}"
+    return rate
+
+
+def oscillation_frequency(
+    df: pd.DataFrame,
+    col: str,
+    *,
+    threshold: float = 0.1,
+    window_seconds: int = 3600,
+) -> pd.Series:
+    """Return how often price direction alternates within ``window_seconds``."""
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    price_diff = df[col].diff()
+    direction = price_diff.apply(
+        lambda x: 1 if x > threshold else (-1 if x < -threshold else 0)
+    )
+    osc = (direction != direction.shift()) & (direction.abs() > 0)
+    series = osc.copy()
+    series.index = df["timestamp"]
+    roll = series.rolling(f"{window_seconds}s", min_periods=1).sum().reset_index(drop=True)
+    freq = roll / (window_seconds / 3600)
+    freq.name = f"oscillation_frequency_{col}"
+    return freq
+
+
+def order_book_imbalance(df: pd.DataFrame, back_size_col: str, lay_size_col: str) -> pd.Series:
+    """Return ``(back_size - lay_size) / (back_size + lay_size)``."""
+    back = df[back_size_col]
+    lay = df[lay_size_col]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        imbalance = (back - lay) / (back + lay)
+        imbalance = imbalance.replace([np.inf, -np.inf], np.nan)
+    imbalance.name = f"order_book_imbalance_{back_size_col}_{lay_size_col}"
+    return imbalance

--- a/tests/test_liquidity_metrics.py
+++ b/tests/test_liquidity_metrics.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from liquidity_metrics import line_adjustment_rate, oscillation_frequency, order_book_imbalance
+
+
+def test_line_adjustment_rate_basic():
+    times = pd.date_range("2021-01-01", periods=5, freq="30min")
+    df = pd.DataFrame({"timestamp": times, "price": [100, 100, 101, 99, 99]})
+    rate = line_adjustment_rate(df, "price", window_seconds=3600)
+    assert list(rate) == [1, 1, 1, 2, 1]
+
+
+def test_oscillation_frequency_basic():
+    times = pd.date_range("2021-01-01", periods=5, freq="h")
+    df = pd.DataFrame({"timestamp": times, "price": [100, 102, 101, 103, 102]})
+    freq = oscillation_frequency(df, "price", threshold=0.1, window_seconds=3600)
+    assert list(freq) == [0, 1, 1, 1, 1]
+
+
+def test_order_book_imbalance():
+    df = pd.DataFrame({"back": [200, 100], "lay": [100, 100]})
+    imbalance = order_book_imbalance(df, "back", "lay")
+    assert np.isclose(imbalance.iloc[0], 1/3)
+    assert imbalance.iloc[1] == 0


### PR DESCRIPTION
## Summary
- implement new liquidity_metrics module for line adjustment, oscillation, and imbalance calculations
- add unit tests covering these metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c509077f4832cb4fbc2bbb332e18e