### PR TITLE
Add implied handle function

### DIFF
--- a/pricing_pressure.py
+++ b/pricing_pressure.py
@@ -41,3 +41,15 @@ def cross_book_disparity(df: pd.DataFrame, sharp_col: str, other_cols: list[str]
     disparity = df[sharp_col] - others_mean
     disparity.name = f"disparity_{sharp_col}_vs_others"
     return disparity
+
+
+def implied_handle(df: pd.DataFrame, opening_odds: float, current_odds: float, k: float = 1.0) -> float:
+    """Estimate the implied handle percentage from an odds move."""
+    if opening_odds == current_odds or opening_odds <= 0 or current_odds <= 0:
+        return 0.0
+    try:
+        ratio = np.log(opening_odds / current_odds)
+        handle = 1 - np.exp(-k * abs(ratio))
+        return float(np.clip(handle, 0.0, 1.0))
+    except Exception:
+        return 0.0

--- a/tests/test_pricing_pressure.py
+++ b/tests/test_pricing_pressure.py
@@ -4,6 +4,7 @@ from pricing_pressure import (
     price_momentum,
     price_acceleration,
     cross_book_disparity,
+    implied_handle,
 )
 
 
@@ -28,3 +29,9 @@ def test_cross_book_disparity():
     )
     disparity = cross_book_disparity(df, "sharp", ["book1", "book2"])
     assert list(disparity) == [0.0, 1.5, 1.5]
+
+
+def test_implied_handle():
+    handle = implied_handle(pd.DataFrame(), 200, 150)
+    assert abs(handle - 0.25) < 1e-6
+    assert implied_handle(pd.DataFrame(), 100, 100) == 0.0


### PR DESCRIPTION
## Summary
- add `implied_handle` helper in pricing_pressure module
- cover new helper with tests

## Testing
- `PYTHONPATH=. pytest -q tests/test_pricing_pressure.py`

------
https://chatgpt.com/codex/tasks/task_e_684caab86ec0832cb1c9f2e5049d9676