### PR TITLE
Add base model feature dictionary helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,9 @@ meta-model ensemble.
 
 - **Inference:**
   In `main.py`, ensemble probabilities are computed for each event by passing
-  the latest base model outputs to `predict_ensemble_probability`.
+  the latest base model outputs to `predict_ensemble_probability`. Use
+  `build_feature_dict` from `ensemble_models.py` to assemble these values
+  consistently.
 
 This approach leverages the unique strengths of each specialized model,
 yielding a win probability that is more robust than any single model alone.

--- a/ensemble_models.py
+++ b/ensemble_models.py
@@ -4,6 +4,44 @@ import pickle
 from sklearn.linear_model import LogisticRegression
 
 
+def build_feature_dict(
+    fundamental_prob,
+    mirror_score,
+    rl_line_adjustment,
+    hybrid_prob,
+    **extra_features,
+):
+    """Assemble the base model outputs into a feature dictionary.
+
+    Parameters
+    ----------
+    fundamental_prob : float
+        Probability predicted by the fundamental model.
+    mirror_score : float
+        Market maker mirror score.
+    rl_line_adjustment : float
+        Adjustment suggested by the RL line model.
+    hybrid_prob : float
+        Probability from the hybrid neural network.
+    **extra_features : float
+        Optional additional feature values.
+
+    Returns
+    -------
+    dict
+        Mapping of feature names to values, ready for ensemble inference.
+    """
+
+    feature_dict = {
+        "fundamental_prob": fundamental_prob,
+        "mirror_score": mirror_score,
+        "rl_line_adjustment": rl_line_adjustment,
+        "hybrid_prob": hybrid_prob,
+    }
+    feature_dict.update(extra_features)
+    return feature_dict
+
+
 def train_ensemble_model(dataset_path, model_out="ensemble_model.pkl"):
     """Train a meta-model to blend base model predictions."""
     df = pd.read_csv(dataset_path)


### PR DESCRIPTION
## Summary
- create `build_feature_dict` to consolidate base model outputs
- document usage of `build_feature_dict` in the ensemble section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce0092818832ca56a1839450ede58