### PR TITLE
Fix CLI training pipeline args

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ This command pulls the latest odds, computes every feature and prints a
 dashboard with the top edges. Results are also saved to ``bet_log.jsonl`` and
 ``bet_recommendations.log``.
 
-To build datasets and retrain the models in one step (example years shown):
+To build the training dataset and retrain the models in one step (example years shown):
 
 ```bash
 python3 main.py --train --years 2018-2024
 ```
+
+This kicks off dataset creation followed by model training.
 
 The old subcommands remain available for advanced workflows but ``--run`` and
 ``--train`` are the recommended one-click options.

--- a/integrate_data.py
+++ b/integrate_data.py
@@ -439,7 +439,7 @@ def add_ml_features(df):
     return df
 
 
-def main():
+def main(argv: list[str] | None = None):
     """Main processing function"""
     # Parse command line arguments
     import argparse
@@ -459,7 +459,7 @@ def main():
         help=f"Output CSV file path (default: {OUTPUT_FILE})",
     )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     print("Starting data integration process...")
     setup_directories()

--- a/main.py
+++ b/main.py
@@ -1275,7 +1275,7 @@ def train_pipeline(*, years: str = "2018-2024", sport: str = "baseball_mlb", ver
     import integrate_data
 
     integrate_data.YEARS_TO_PROCESS = year_range
-    integrate_data.main()
+    integrate_data.main([])
     dataset_path = integrate_data.OUTPUT_FILE
 
     train_dual_head_classifier(dataset_path, verbose=verbose)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,3 +51,19 @@ def test_train_mirror_cli_invocation(monkeypatch):
     monkeypatch.setattr(main, 'train_market_maker_mirror_model', fake_train)
     main.main(['train_mirror', '--dataset', 'd.csv'])
     assert called.get('dataset') == 'd.csv'
+
+
+def test_train_pipeline_no_unrecognized_args(monkeypatch):
+    called = {}
+
+    def fake_integrate(argv=None):
+        called['argv'] = argv
+
+    import integrate_data
+
+    monkeypatch.setattr(integrate_data, 'main', fake_integrate)
+    monkeypatch.setattr(main, 'train_dual_head_classifier', lambda *a, **k: None)
+    monkeypatch.setattr(main, 'train_h2h_classifier', lambda *a, **k: None, raising=False)
+
+    main.main(['--train', '--years', '2018-2024'])
+    assert called.get('argv') == []


### PR DESCRIPTION
## Summary
- allow `integrate_data.main()` to accept an optional argument list
- invoke `integrate_data.main([])` from the training pipeline
- document that `--train` builds the dataset and trains models
- ensure CLI training pipeline passes empty args in regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d04ff47c0832c87d494c7fa95405c