### PR TITLE
Add odds cache script

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,17 @@ This regime analysis lets the system recognize and adapt to diverse market
 behaviors, augmenting raw volatility and pricing-pressure features for richer
 modeling of line movement dynamics.
 
+#### Fetching Historical Odds Cache
+
+Historical API responses can be cached with ``fetch_odds_cache.py``:
+
+```bash
+python3 fetch_odds_cache.py --start-date=2024-01-01 --end-date=2024-01-31 --sport=baseball_mlb
+```
+
+Each day's JSON is saved to ``h2h_data/api_cache/YYYY-MM-DD.pkl``. Existing files
+are skipped so the command can be run incrementally.
+
 #### Unsupervised Representation Learning
 
 The toolkit uses a sequence autoencoder to learn latent embeddings of moneyline movement.
@@ -401,9 +412,8 @@ Before training the autoencoder, gather odds timelines from your cached API resp
 python3 prepare_autoencoder_dataset.py
 ```
 ``prepare_autoencoder_dataset.py`` expects ``h2h_data/api_cache`` to already contain
-historical responses from The Odds API. The repository does **not** provide a script
-to download these files—you must fetch the raw API results yourself and store them in
-that directory.
+historical responses from The Odds API. Use ``fetch_odds_cache.py`` to download these
+files and store them in that directory.
 
 This command collects all ``odds_timeline`` entries under ``h2h_data/api_cache`` and
 writes ``h2h_data/api_cache/odds_timelines.pkl``. Supply this file to

--- a/fetch_odds_cache.py
+++ b/fetch_odds_cache.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Download historical odds and cache them locally."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import requests
+
+API_KEY = os.getenv("THE_ODDS_API_KEY")
+CACHE_DIR = Path("h2h_data") / "api_cache"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch historical odds")
+    parser.add_argument("--start-date", required=True, help="First date YYYY-MM-DD")
+    parser.add_argument("--end-date", required=True, help="Last date YYYY-MM-DD")
+    parser.add_argument(
+        "--sport",
+        default="baseball_mlb",
+        help="Sport key used by The Odds API",
+    )
+    return parser.parse_args(argv)
+
+
+def fetch_historical_odds(sport: str, date: str) -> list:
+    """Return odds data for ``sport`` on ``date``."""
+    if not API_KEY:
+        raise RuntimeError("THE_ODDS_API_KEY environment variable is not set")
+    url = f"https://api.the-odds-api.com/v4/sports/{sport}/odds-history/"
+    params = {
+        "apiKey": API_KEY,
+        "regions": "us",
+        "markets": "h2h",
+        "oddsFormat": "american",
+        "date": date,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def daterange(start: datetime, end: datetime):
+    day = timedelta(days=1)
+    current = start
+    while current <= end:
+        yield current
+        current += day
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    start = datetime.fromisoformat(args.start_date)
+    end = datetime.fromisoformat(args.end_date)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    for d in daterange(start, end):
+        date_str = d.strftime("%Y-%m-%d")
+        cache_path = CACHE_DIR / f"{date_str}.pkl"
+        if cache_path.exists():
+            print(f"Using existing {cache_path}")
+            continue
+        try:
+            data = fetch_historical_odds(args.sport, date_str)
+        except Exception as exc:  # pragma: no cover - network error handling
+            print(f"Error fetching {date_str}: {exc}")
+            continue
+        with open(cache_path, "wb") as f:
+            pickle.dump(data, f)
+        print(f"Saved odds for {date_str}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fetch_odds_cache.py` for downloading daily historical odds
- describe the new caching workflow in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_684d1bcf8010832c9751577e4708ccbd