### PR TITLE
Load API key from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ pip3 install -r requirements-dev.txt
 export THE_ODDS_API_KEY=<your api key>
 ```
 
+You can alternatively place the key in a `.env` file at the repository root.
+Scripts such as `main.py` and `fetch_odds_cache.py` load this file
+automatically so you don't have to export the variable each time.
+
 If the variable is omitted the script runs in a limited *test mode* without
 making any API requests.
 

--- a/fetch_odds_cache.py
+++ b/fetch_odds_cache.py
@@ -9,7 +9,17 @@ import pickle
 from datetime import datetime, timedelta
 from pathlib import Path
 
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
 import requests
+
+ROOT_DIR = Path(__file__).resolve().parent
+DOTENV_PATH = ROOT_DIR / ".env"
+if load_dotenv and DOTENV_PATH.exists():
+    load_dotenv(DOTENV_PATH)
 
 API_KEY = os.getenv("THE_ODDS_API_KEY")
 CACHE_DIR = Path("h2h_data") / "api_cache"


### PR DESCRIPTION
## Summary
- automatically load environment variables from `.env` in `fetch_odds_cache.py`
- document `.env` usage in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d27592a5c832c8a6375f1de653ad6