### PR TITLE
Add odds timeline fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,15 @@ python3 fetch_odds_cache.py --sport=baseball_mlb \
 ```
 
 Each day's API response is saved under ``h2h_data/api_cache``.
+Next download per-event timelines with ``fetch_odds_timelines.py``:
+
+```bash
+python3 fetch_odds_timelines.py --sport=baseball_mlb \
+    --start-date=2024-04-01 --end-date=2024-04-30
+```
+
+This writes ``h2h_data/api_cache/<event_id>.pkl`` files containing an
+``odds_timeline`` DataFrame for every game.
 Once these cache files exist, run ``prepare_autoencoder_dataset.py`` to build the timeline dataset:
 
 ```bash

--- a/fetch_odds_timelines.py
+++ b/fetch_odds_timelines.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Download historical odds timelines for each event."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+import pandas as pd
+import requests
+
+ROOT_DIR = Path(__file__).resolve().parent
+DOTENV_PATH = ROOT_DIR / ".env"
+if load_dotenv and DOTENV_PATH.exists():
+    load_dotenv(DOTENV_PATH)
+
+API_KEY = os.getenv("THE_ODDS_API_KEY")
+CACHE_DIR = Path("h2h_data") / "api_cache"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch odds timelines")
+    parser.add_argument("--start-date", required=True, help="First date YYYY-MM-DD")
+    parser.add_argument("--end-date", required=True, help="Last date YYYY-MM-DD")
+    parser.add_argument(
+        "--sport",
+        default="baseball_mlb",
+        help="Sport key used by The Odds API",
+    )
+    return parser.parse_args(argv)
+
+
+def to_fixed_utc(date_obj: datetime) -> str:
+    """Return ISO string for ``date_obj`` fixed at 12:00 UTC."""
+    return date_obj.strftime("%Y-%m-%dT12:00:00Z")
+
+
+def fetch_historical_odds(sport: str, date_iso: str) -> list:
+    """Return odds data for ``sport`` on ``date_iso``."""
+    if not API_KEY:
+        raise RuntimeError("THE_ODDS_API_KEY environment variable is not set")
+    url = f"https://api.the-odds-api.com/v4/historical/sports/{sport}/odds"
+    params = {
+        "apiKey": API_KEY,
+        "regions": "us",
+        "markets": "h2h",
+        "oddsFormat": "american",
+        "date": date_iso,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_odds_history(sport: str, event_id: str) -> list | dict:
+    """Return odds history for ``event_id``."""
+    if not API_KEY:
+        raise RuntimeError("THE_ODDS_API_KEY environment variable is not set")
+    url = f"https://api.the-odds-api.com/v4/sports/{sport}/events/{event_id}/odds-history"
+    params = {
+        "apiKey": API_KEY,
+        "regions": "us",
+        "markets": "h2h",
+        "oddsFormat": "american",
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def daterange(start: datetime, end: datetime):
+    day = timedelta(days=1)
+    current = start
+    while current <= end:
+        yield current
+        current += day
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    start = datetime.fromisoformat(args.start_date)
+    end = datetime.fromisoformat(args.end_date)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    for d in daterange(start, end):
+        date_iso = to_fixed_utc(d)
+        try:
+            events = fetch_historical_odds(args.sport, date_iso)
+        except Exception as exc:  # pragma: no cover - network error handling
+            print(f"Error fetching events for {d.date()}: {exc}")
+            continue
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            event_id = event.get("id")
+            if not event_id:
+                continue
+            cache_path = CACHE_DIR / f"{event_id}.pkl"
+            if cache_path.exists():
+                print(f"Using existing {cache_path}")
+                continue
+            try:
+                hist = fetch_odds_history(args.sport, event_id)
+            except Exception as exc:  # pragma: no cover - network error handling
+                print(f"Error fetching history for {event_id}: {exc}")
+                continue
+            df = pd.DataFrame(hist)
+            data = {"odds_timeline": df}
+            with open(cache_path, "wb") as f:
+                pickle.dump(data, f)
+            print(f"Saved timeline for {event_id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to pull event-level odds history
- document running `fetch_odds_timelines.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2efbd854832c805ac9e0297b5247