### PR TITLE
Fix API key loading

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -7,6 +7,19 @@ import pickle
 import warnings
 
 import requests
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+ROOT_DIR = Path(__file__).resolve().parent
+DOTENV_PATH = ROOT_DIR / ".env"
+if load_dotenv and DOTENV_PATH.exists():
+    load_dotenv(DOTENV_PATH)
+
+API_KEY = os.getenv("THE_ODDS_API_KEY")
 
 # Access model path constants from main without creating a circular import
 from typing import Optional


### PR DESCRIPTION
## Summary
- ensure ml uses `.env` to load THE_ODDS_API_KEY

## Testing
- `python3 cache_historical_odds.py --sport=baseball_mlb --start-date=2024-04-01 --end-date=2024-04-03`
- `pytest -q` *(fails: `torch` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dae99da5c832c824c4ee6d6a4bcb2