### PR TITLE
Improve odds timeline debug info

### DIFF
--- a/prepare_autoencoder_dataset.py
+++ b/prepare_autoencoder_dataset.py
@@ -9,9 +9,13 @@ CACHE_DIR = Path("h2h_data/api_cache")
 OUT_FILE = CACHE_DIR / "odds_timelines.pkl"
 
 
-def extract_odds_timelines(cache_dir: Path) -> list[pd.DataFrame]:
+def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[str]]:
+    """Return timelines and inspected filenames found under ``cache_dir``."""
+
     timelines: list[pd.DataFrame] = []
+    inspected: list[str] = []
     for fp in cache_dir.glob("*.pkl"):
+        inspected.append(fp.name)
         try:
             with open(fp, "rb") as f:
                 cached = pickle.load(f)
@@ -19,10 +23,12 @@ def extract_odds_timelines(cache_dir: Path) -> list[pd.DataFrame]:
             print(f"Error reading {fp}: {e}")
             continue
 
+        found = False
         if isinstance(cached, dict) and "odds_timeline" in cached:
             timeline = cached["odds_timeline"]
             if isinstance(timeline, pd.DataFrame) and {"timestamp", "price"}.issubset(timeline.columns):
                 timelines.append(timeline[["timestamp", "price"]].copy())
+                found = True
 
         events = (
             cached.get("data")
@@ -31,28 +37,33 @@ def extract_odds_timelines(cache_dir: Path) -> list[pd.DataFrame]:
         )
         if isinstance(events, dict):
             events = [events]
-        if not isinstance(events, list):
-            continue
+        if isinstance(events, list):
+            for event in events:
+                if not isinstance(event, dict):
+                    continue
+                for book in event.get("bookmakers", []):
+                    for market in book.get("markets", []):
+                        for outcome in market.get("outcomes", []):
+                            timeline = outcome.get("odds_timeline")
+                            if isinstance(timeline, pd.DataFrame) and {
+                                "price",
+                                "timestamp",
+                            }.issubset(timeline.columns):
+                                timelines.append(timeline[["timestamp", "price"]].copy())
+                                found = True
 
-        for event in events:
-            if not isinstance(event, dict):
-                continue
-            for book in event.get("bookmakers", []):
-                for market in book.get("markets", []):
-                    for outcome in market.get("outcomes", []):
-                        timeline = outcome.get("odds_timeline")
-                        if isinstance(timeline, pd.DataFrame) and {
-                            "price",
-                            "timestamp",
-                        }.issubset(timeline.columns):
-                            timelines.append(timeline[["timestamp", "price"]].copy())
-    return timelines
+        if not found:
+            print(f"No odds_timeline in {fp.name}")
+
+    return timelines, inspected
 
 
 def main() -> None:
-    timelines = extract_odds_timelines(CACHE_DIR)
+    timelines, inspected = extract_odds_timelines(CACHE_DIR)
     if not timelines:
         print("No odds timelines found in cache")
+        if inspected:
+            print("Inspected files: " + ", ".join(sorted(inspected)))
         return
     OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(OUT_FILE, "wb") as f:

--- a/tests/test_prepare_autoencoder_dataset.py
+++ b/tests/test_prepare_autoencoder_dataset.py
@@ -1,6 +1,6 @@
 import pickle
 import pandas as pd
-from prepare_autoencoder_dataset import extract_odds_timelines
+from prepare_autoencoder_dataset import extract_odds_timelines, main
 
 
 def test_extract_odds_timelines_top_level(tmp_path):
@@ -8,6 +8,32 @@ def test_extract_odds_timelines_top_level(tmp_path):
     with open(tmp_path / "a.pkl", "wb") as f:
         pickle.dump({"odds_timeline": df}, f)
 
-    timelines = extract_odds_timelines(tmp_path)
+    timelines, files = extract_odds_timelines(tmp_path)
     assert len(timelines) == 1
+    assert files == ["a.pkl"]
     pd.testing.assert_frame_equal(timelines[0], df[["timestamp", "price"]])
+
+
+def test_extract_odds_timelines_missing(tmp_path, capsys):
+    with open(tmp_path / "missing.pkl", "wb") as f:
+        pickle.dump({}, f)
+
+    timelines, files = extract_odds_timelines(tmp_path)
+    out = capsys.readouterr().out
+    assert "No odds_timeline in missing.pkl" in out
+    assert timelines == []
+    assert files == ["missing.pkl"]
+
+
+def test_main_no_timelines(monkeypatch, tmp_path, capsys):
+    with open(tmp_path / "x.pkl", "wb") as f:
+        pickle.dump({}, f)
+
+    monkeypatch.setattr("prepare_autoencoder_dataset.CACHE_DIR", tmp_path)
+    monkeypatch.setattr("prepare_autoencoder_dataset.OUT_FILE", tmp_path / "out.pkl")
+    main()
+    out = capsys.readouterr().out
+    assert "No odds timelines found in cache" in out
+    assert "x.pkl" in out
+    assert "Inspected files:" in out
+    assert not (tmp_path / "out.pkl").exists()


### PR DESCRIPTION
## Summary
- add per-file warnings when odds timelines are missing
- list inspected files when none are discovered
- test that debugging information works

## Testing
- `python -m pytest tests/test_prepare_autoencoder_dataset.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684db568ac9c832caabd70de7db87068