### PR TITLE
Update docs on historical odds caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This script fetches odds from [The Odds API](https://the-odds-api.com/).
 It requires **Python 3**.
 
+`cache_historical_odds.py` saves daily snapshot odds but does **not** include
+timeline updates. Run `fetch_odds_timelines.py` first if you need the complete
+sequence of line movements.
+
 ## Installation
 
 Install the core dependencies with:

--- a/cache_historical_odds.py
+++ b/cache_historical_odds.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Stores daily snapshot odds only; timelines require ``fetch_odds_timelines.py``.
 """Fetch historical odds from The Odds API and save them to the cache."""
 
 import argparse


### PR DESCRIPTION
## Summary
- clarify that `cache_historical_odds.py` stores daily odds snapshots only
- point readers to `fetch_odds_timelines.py` for timeline data

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: libtorch_global_deps.so cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_684db7cb436c832c9b939b6b05f372f2