### PR TITLE
Implement snapshot timeline converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,17 @@ python3 fetch_odds_cache.py --start-date=2024-01-01 --end-date=2024-01-31 --spor
 Each day's JSON is saved to ``h2h_data/api_cache/YYYY-MM-DD.pkl``. Existing files
 are skipped so the command can be run incrementally.
 
+After collecting several daily snapshots you can convert them into per-event
+timelines:
+
+```bash
+python3 snapshot_to_timeline.py
+```
+
+This aggregates the prices for each ``event_id`` across all snapshot files and
+saves ``h2h_data/api_cache/<event_id>.pkl`` with an ``odds_timeline`` DataFrame
+ready for ``prepare_autoencoder_dataset.py``.
+
 #### Unsupervised Representation Learning
 
 ##### Why Odds Timeline Data Is Needed

--- a/snapshot_to_timeline.py
+++ b/snapshot_to_timeline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Aggregate daily snapshot odds into event timelines."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+
+CACHE_DIR = Path("h2h_data/api_cache")
+
+
+def _read_snapshot(fp: Path) -> list[dict]:
+    """Return event list stored in snapshot ``fp``."""
+    with open(fp, "rb") as f:
+        data = pickle.load(f)
+    if isinstance(data, dict) and "data" in data:
+        data = data["data"]
+    return data if isinstance(data, list) else []
+
+
+def _parse_timestamp(fp: Path) -> pd.Timestamp | None:
+    try:
+        dt = datetime.fromisoformat(fp.stem)
+    except ValueError:
+        return None
+    return pd.Timestamp(dt)
+
+
+def main() -> None:
+    event_rows: dict[str, list[dict]] = {}
+
+    for fp in sorted(CACHE_DIR.glob("*.pkl")):
+        ts = _parse_timestamp(fp)
+        if ts is None:
+            continue
+        for event in _read_snapshot(fp):
+            if not isinstance(event, dict):
+                continue
+            event_id = event.get("id")
+            if not event_id:
+                continue
+            price = None
+            for book in event.get("bookmakers", []):
+                for market in book.get("markets", []):
+                    if market.get("key") != "h2h":
+                        continue
+                    if not market.get("outcomes"):
+                        continue
+                    outcome = market["outcomes"][0]
+                    price = outcome.get("price")
+                    if price is not None:
+                        break
+                if price is not None:
+                    break
+            if price is None:
+                continue
+            event_rows.setdefault(event_id, []).append({"timestamp": ts, "price": price})
+
+    for event_id, rows in event_rows.items():
+        df = pd.DataFrame(rows).sort_values("timestamp").reset_index(drop=True)
+        with open(CACHE_DIR / f"{event_id}.pkl", "wb") as f:
+            pickle.dump({"odds_timeline": df}, f)
+        print(f"Saved timeline for {event_id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `snapshot_to_timeline.py` for aggregating daily snapshots into per-event timelines
- document the new conversion step in the README

## Testing
- `pip install pandas numpy scikit-learn requests`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0`
- `pip install python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc5caf94c832c8c15b93832b37ca8