### PR TITLE
Add snapshot interval collector script

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,14 @@ python3 fetch_odds_cache.py --start-date=2024-01-01 --end-date=2024-01-31 --spor
 Each day's JSON is saved to ``h2h_data/api_cache/YYYY-MM-DD.pkl``. Existing files
 are skipped so the command can be run incrementally.
 
+To capture multiple snapshots throughout the day use
+``collect_snapshot_intervals.py``. It repeatedly queries the historical odds API
+on a fixed interval and saves each response with a timestamped filename:
+
+```bash
+python3 collect_snapshot_intervals.py --interval 5 --duration 60
+```
+
 After collecting several daily snapshots you can convert them into per-event
 timelines:
 

--- a/collect_snapshot_intervals.py
+++ b/collect_snapshot_intervals.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Periodically fetch historical odds snapshots and cache them."""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from ml import fetch_historical_h2h_odds
+
+CACHE_DIR = Path("h2h_data/api_cache")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect repeated historical odds snapshots"
+    )
+    parser.add_argument("--sport", default="baseball_mlb")
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=5,
+        help="Snapshot interval in minutes",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=60,
+        help="Total run time in minutes",
+    )
+    return parser.parse_args(argv)
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time in ISO format with 'Z' suffix."""
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    interval_sec = args.interval * 60
+    end_time = time.time() + args.duration * 60
+
+    while time.time() < end_time:
+        date_iso = utc_now_iso()
+        events = fetch_historical_h2h_odds(args.sport, date_iso)
+        if events:
+            ts_str = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%SZ")
+            out_file = CACHE_DIR / f"{ts_str}.pkl"
+            with open(out_file, "wb") as f:
+                pickle.dump({"data": events}, f)
+            print(f"Saved {len(events)} events to {out_file}")
+        else:
+            print("No events found")
+
+        remaining = end_time - time.time()
+        if remaining <= 0:
+            break
+        time.sleep(min(interval_sec, remaining))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `collect_snapshot_intervals.py` for repeated historical odds polling
- document using the new script in README

## Testing
- `pip install pandas numpy scikit-learn`
- `pip install python-dotenv requests torch --extra-index-url https://download.pytorch.org/whl/cpu -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcc0d4ac0832c8b093b94898c5190