### PR TITLE
Improve snapshot timestamp parsing

### DIFF
--- a/snapshot_to_timeline.py
+++ b/snapshot_to_timeline.py
@@ -22,8 +22,9 @@ def _read_snapshot(fp: Path) -> list[dict]:
 
 
 def _parse_timestamp(fp: Path) -> pd.Timestamp | None:
+    """Parse timestamp from snapshot filename."""
     try:
-        dt = datetime.fromisoformat(fp.stem)
+        dt = datetime.strptime(fp.stem, "%Y-%m-%dT%H-%M-%SZ")
     except ValueError:
         return None
     return pd.Timestamp(dt)

--- a/tests/test_snapshot_to_timeline.py
+++ b/tests/test_snapshot_to_timeline.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import snapshot_to_timeline as st
+
+
+def test_parse_timestamp_hyphenated():
+    fp = Path("2024-06-08T12-30-45Z.pkl")
+    ts = st._parse_timestamp(fp)
+    assert ts == pd.Timestamp(datetime(2024, 6, 8, 12, 30, 45))
+


### PR DESCRIPTION
## Summary
- handle hyphenated timestamps in `snapshot_to_timeline`
- test parsing of hyphenated snapshot filenames
- remove fallback parsing logic

## Testing
- `pytest tests/test_snapshot_to_timeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684efbd5378c832c9174faa39760a803