### PR TITLE
Improve snapshot timestamp parsing

### DIFF
--- a/snapshot_to_timeline.py
+++ b/snapshot_to_timeline.py
@@ -22,11 +22,16 @@ def _read_snapshot(fp: Path) -> list[dict]:
 
 
 def _parse_timestamp(fp: Path) -> pd.Timestamp | None:
+    """Parse timestamp from snapshot filename."""
+    ts = None
     try:
-        dt = datetime.fromisoformat(fp.stem)
+        ts = datetime.strptime(fp.stem, "%Y-%m-%dT%H-%M-%SZ")
     except ValueError:
-        return None
-    return pd.Timestamp(dt)
+        try:
+            ts = datetime.fromisoformat(fp.stem.replace("Z", "+00:00")).replace(tzinfo=None)
+        except ValueError:
+            return None
+    return pd.Timestamp(ts)
 
 
 def main() -> None:

--- a/tests/test_snapshot_to_timeline.py
+++ b/tests/test_snapshot_to_timeline.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import snapshot_to_timeline as st
+
+
+def test_parse_timestamp_hyphenated():
+    fp = Path("2024-06-08T12-30-45Z.pkl")
+    ts = st._parse_timestamp(fp)
+    assert ts == pd.Timestamp(datetime(2024, 6, 8, 12, 30, 45))
+
+
+def test_parse_timestamp_iso():
+    fp = Path("2024-06-08T12:30:45Z.pkl")
+    ts = st._parse_timestamp(fp)
+    assert ts == pd.Timestamp(datetime(2024, 6, 8, 12, 30, 45))
+
+
+def test_parse_timestamp_invalid():
+    fp = Path("not-a-timestamp.pkl")
+    assert st._parse_timestamp(fp) is None
+


### PR DESCRIPTION
## Summary
- handle both hyphenated and ISO snapshot filenames
- test parsing of hyphenated and ISO snapshot timestamps
- validate invalid filenames return `None`

## Testing
- `pytest tests/test_snapshot_to_timeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684efbd5378c832c9174faa39760a803