### PR TITLE
Handle alternative timestamp formats

### DIFF
--- a/snapshot_to_timeline.py
+++ b/snapshot_to_timeline.py
@@ -24,9 +24,14 @@ def _read_snapshot(fp: Path) -> list[dict]:
 def _parse_timestamp(fp: Path) -> pd.Timestamp | None:
     """Parse timestamp from snapshot filename."""
 
+    try:
+        ts = datetime.strptime(fp.stem, "%Y-%m-%dT%H-%M-%SZ")
     except ValueError:
         try:
-            ts = datetime.fromisoformat(fp.stem.replace("Z", "+00:00")).replace(tzinfo=None)
+            ts = (
+                datetime.fromisoformat(fp.stem.replace("Z", "+00:00"))
+                .replace(tzinfo=None)
+            )
         except ValueError:
             return None
     return pd.Timestamp(ts)

--- a/tests/test_snapshot_to_timeline.py
+++ b/tests/test_snapshot_to_timeline.py
@@ -15,3 +15,9 @@ def test_parse_timestamp_hyphenated():
     ts = st._parse_timestamp(fp)
     assert ts == pd.Timestamp(datetime(2024, 6, 8, 12, 30, 45))
 
+
+def test_parse_timestamp_colon():
+    fp = Path("2024-06-08T12:30:45Z.pkl")
+    ts = st._parse_timestamp(fp)
+    assert ts == pd.Timestamp(datetime(2024, 6, 8, 12, 30, 45))
+


### PR DESCRIPTION
## Summary
- support hyphenated and colon timestamp formats in `snapshot_to_timeline._parse_timestamp`
- test timestamp parsing for both formats

## Testing
- `pytest tests/test_snapshot_to_timeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f09030e44832cb85ff918c98394a8