### PR TITLE
Fix regime feature window check

### DIFF
--- a/market_regime_clustering.py
+++ b/market_regime_clustering.py
@@ -42,6 +42,11 @@ def derive_regime_features(
             "At least two data points are required to derive regime features"
         )
 
+    # Ensure enough samples exist within the rolling volatility window
+    window_start = df["timestamp"].iloc[-1] - pd.Timedelta(seconds=window_seconds)
+    if (df["timestamp"] >= window_start).sum() < 2:
+        raise ValueError("Insufficient data within window")
+
     features[f"total_line_change_{price_col}"] = total_line_change(df, price_col)
     features[f"largest_move_timing_{price_col}"] = largest_move_timing(df, price_col)
     vol = compute_odds_volatility(


### PR DESCRIPTION
## Summary
- ensure sufficient data exists within the rolling window when deriving regime features
- run tests

## Testing
- `pytest tests/test_market_regime_clustering.py::test_derive_regime_features_insufficient_window_data -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f384327f0832cbe0f36fa3908af13