### PR TITLE
Fix dataset search for autoencoder

### DIFF
--- a/prepare_autoencoder_dataset.py
+++ b/prepare_autoencoder_dataset.py
@@ -25,7 +25,7 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
     inspected: list[str] = []
     event_rows: dict[str, list[dict]] = {}
     event_files: dict[str, set[str]] = {}
-    for fp in cache_dir.glob("*.pkl"):
+    for fp in cache_dir.rglob("*.pkl"):
         inspected.append(fp.name)
         try:
             with open(fp, "rb") as f:

--- a/tests/test_prepare_autoencoder_dataset.py
+++ b/tests/test_prepare_autoencoder_dataset.py
@@ -61,6 +61,19 @@ def test_extract_odds_timelines_assemble(tmp_path):
     pd.testing.assert_frame_equal(timelines[0].reset_index(drop=True), expected)
 
 
+def test_extract_odds_timelines_nested(tmp_path):
+    df = pd.DataFrame({"timestamp": [1], "price": [100]})
+    sub = tmp_path / "nested"
+    sub.mkdir()
+    with open(sub / "b.pkl", "wb") as f:
+        pickle.dump({"odds_timeline": df}, f)
+
+    timelines, files = extract_odds_timelines(tmp_path)
+    assert len(timelines) == 1
+    assert files == ["b.pkl"]
+    pd.testing.assert_frame_equal(timelines[0], df[["timestamp", "price"]])
+
+
 def test_main_no_timelines(monkeypatch, tmp_path, capsys):
     with open(tmp_path / "x.pkl", "wb") as f:
         pickle.dump({}, f)


### PR DESCRIPTION
## Summary
- search recursively for odds timelines when building autoencoder dataset
- add regression test for nested timeline files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850a16c02b8832cbab111469a3706de