### PR TITLE
Improve dataset builder path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ distinct from ``cache_historical_odds.py``—that helper stores only daily odds
 snapshots and does not provide the ``odds_timeline`` data required for the
 autoencoder.
 
+``prepare_autoencoder_dataset.py`` now searches every ``.pkl`` file under
+``h2h_data`` by default. Specify ``--cache-dir`` if your files live elsewhere,
+and ``--out-file`` to customize where the aggregated timelines are written.
+
 The toolkit uses a sequence autoencoder to learn latent embeddings of moneyline movement.
 An LSTM-based autoencoder is trained to reconstruct normalized odds timelines; the hidden state ("latent vector") summarizes the dynamic pattern of each event’s line moves.
 These embeddings (autoencoder_feature_1, autoencoder_feature_2, ...) are added to every example for model training and live inference.
@@ -475,9 +479,9 @@ _No fallback or bandage models are included; the autoencoder is trained directly
 python3 prepare_autoencoder_dataset.py
 ```
 
-This command collects all ``odds_timeline`` entries under ``h2h_data/api_cache`` and
-writes ``h2h_data/api_cache/odds_timelines.pkl``. Supply this file to
-``train_sequence_autoencoder``.
+This command collects all ``odds_timeline`` entries under the specified cache
+directory (``h2h_data`` by default) and writes ``odds_timelines.pkl``. Supply
+this file to ``train_sequence_autoencoder``.
 
 ### Reinforcement Learning Market Maker
 

--- a/prepare_autoencoder_dataset.py
+++ b/prepare_autoencoder_dataset.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Collect odds timelines for sequence autoencoder training."""
 
+import argparse
 import pickle
 from pathlib import Path
 from datetime import datetime
 
 import pandas as pd
 
-CACHE_DIR = Path("h2h_data/api_cache")
-OUT_FILE = CACHE_DIR / "odds_timelines.pkl"
+
+DEFAULT_CACHE_DIR = Path("h2h_data")
+DEFAULT_OUT_FILE = DEFAULT_CACHE_DIR / "api_cache" / "odds_timelines.pkl"
 
 
 def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[str]]:
@@ -37,7 +39,9 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
         found = False
         if isinstance(cached, dict) and "odds_timeline" in cached:
             timeline = cached["odds_timeline"]
-            if isinstance(timeline, pd.DataFrame) and {"timestamp", "price"}.issubset(timeline.columns):
+            if isinstance(timeline, pd.DataFrame) and {"timestamp", "price"}.issubset(
+                timeline.columns
+            ):
                 timelines.append(timeline[["timestamp", "price"]].copy())
                 found = True
 
@@ -60,7 +64,9 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
                                 "price",
                                 "timestamp",
                             }.issubset(timeline.columns):
-                                timelines.append(timeline[["timestamp", "price"]].copy())
+                                timelines.append(
+                                    timeline[["timestamp", "price"]].copy()
+                                )
                                 found = True
 
                 # Build timeline dynamically from snapshot data
@@ -82,7 +88,9 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
                                 break
                         ts = _parse_timestamp(fp)
                         if price is not None and ts is not None:
-                            event_rows.setdefault(event_id, []).append({"timestamp": ts, "price": price})
+                            event_rows.setdefault(event_id, []).append(
+                                {"timestamp": ts, "price": price}
+                            )
                             event_files.setdefault(event_id, set()).add(fp.name)
 
         if not found:
@@ -98,16 +106,31 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
 
 
 def main() -> None:
-    timelines, inspected = extract_odds_timelines(CACHE_DIR)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_DIR,
+        help="Directory containing cached odds .pkl files",
+    )
+    parser.add_argument(
+        "--out-file",
+        type=Path,
+        default=DEFAULT_OUT_FILE,
+        help="Where to store the aggregated timeline dataset",
+    )
+    args = parser.parse_args()
+
+    timelines, inspected = extract_odds_timelines(args.cache_dir)
     if not timelines:
         print("No odds timelines found in cache")
         if inspected:
             print("Inspected files: " + ", ".join(sorted(inspected)))
         return
-    OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(OUT_FILE, "wb") as f:
+    args.out_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out_file, "wb") as f:
         pickle.dump(timelines, f)
-    print(f"Saved {len(timelines)} timelines to {OUT_FILE}")
+    print(f"Saved {len(timelines)} timelines to {args.out_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- search entire `h2h_data` tree when building the autoencoder dataset
- allow `--cache-dir` and `--out-file` options
- document new behaviour in README

## Testing
- `black -q prepare_autoencoder_dataset.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850a3a2dddc832c8ba96e08d73d96f3