### PR TITLE
Add default aggregated dataset output

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,9 @@ To gather a long-range set of odds timelines in one step run:
 python3 fetch_historical_timelines.py --sport=baseball_mlb \
     --start-date=2024-01-01 --end-date=2024-12-31 --interval=60
 ```
+By default every timeline is aggregated into
+``h2h_data/api_cache/snapshot_data.pkl`` which can be fed directly to the
+autoencoder. Use ``--out-file`` to override the location.
 
 
 #### Unsupervised Representation Learning

--- a/prepare_autoencoder_dataset.py
+++ b/prepare_autoencoder_dataset.py
@@ -41,6 +41,13 @@ def extract_odds_timelines(cache_dir: Path) -> tuple[list[pd.DataFrame], list[st
             continue
 
         found = False
+        if isinstance(cached, list) and all(isinstance(df, pd.DataFrame) for df in cached):
+            for df in cached:
+                if {"timestamp", "price"}.issubset(df.columns):
+                    timelines.append(df[["timestamp", "price"]].copy())
+                    found = True
+            if found:
+                continue
         if isinstance(cached, dict) and "odds_timeline" in cached:
             timeline = cached["odds_timeline"]
             if isinstance(timeline, pd.DataFrame) and {"timestamp", "price"}.issubset(


### PR DESCRIPTION
## Summary
- aggregate historical timelines into `snapshot_data.pkl` by default
- show default behavior in the README
- allow `prepare_autoencoder_dataset.py` to parse aggregated timeline files

## Testing
- `PYTHONPATH=/usr/lib/python3/dist-packages:$PYTHONPATH python3 -m pytest -q` *(fails: ModuleNotFoundError for joblib/torch/sklearn)*

------
https://chatgpt.com/codex/tasks/task_e_6850e7916e7c832cafbbc738279bd53a