### PR TITLE
Persist aggregated odds timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ python3 fetch_historical_timelines.py --sport=baseball_mlb \
     --start-date=2024-01-01 --end-date=2024-12-31 --interval=60
 ```
 By default every timeline is aggregated into
-``h2h_data/api_cache/snapshot_data.pkl`` which can be fed directly to the
+``snapshot_data.pkl`` which can be fed directly to the
 autoencoder. Use ``--out-file`` to override the location.
 
 


### PR DESCRIPTION
## Summary
- output aggregated timeline dataset to `snapshot_data.pkl`
- document new default location
- show aggregated output file path at runtime
- merge with any previously saved data when collecting new timelines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512301e090832c9a4720c6e32652f2